### PR TITLE
Fix Hassfest validation error

### DIFF
--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -15,14 +15,15 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 
 from .const import (
-    PPC_URL,
-    PPC_DEFAULT_NAME,
-    THEBEN_URL,
-    THEBEN_DEFAULT_NAME,
+    CONF_METER_TYPE,
+    DEFAULT_DEBUG,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    DEFAULT_DEBUG,
-    CONF_METER_TYPE,
+    PPC_DEFAULT_NAME,
+    PPC_URL,
+    REPO_URL,
+    THEBEN_DEFAULT_NAME,
+    THEBEN_URL,
 )
 from .gateways.vendors import Vendor
 
@@ -108,7 +109,10 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_connection_info(user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=SCHEMA_VENDOR, errors=self._errors
+            step_id="user",
+            data_schema=SCHEMA_VENDOR,
+            errors=self._errors,
+            description_placeholders={"repo_url": REPO_URL},
         )
 
     async def async_step_connection_details(
@@ -170,6 +174,7 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             last_step=True,
             errors=self._errors,
+            description_placeholders={"repo_url": REPO_URL},
         )
 
     @staticmethod
@@ -220,6 +225,7 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="user",
             data_schema=data_schema,
+            description_placeholders={"repo_url": REPO_URL},
         )
 
     def _update_options(self):

--- a/custom_components/ppc_smgw/const.py
+++ b/custom_components/ppc_smgw/const.py
@@ -13,6 +13,8 @@ DEFAULT_PASSWORD = ""
 DEFAULT_SCAN_INTERVAL = 5
 DEFAULT_DEBUG = False
 
+REPO_URL = "https://github.com/jannickfahlbusch/ha-ppc-smgw"
+
 PPC_DEFAULT_NAME = "PPC SMGW"
 PPC_DEFAULT_MODEL = "LTE Smart Meter Gateway"
 PPC_MANUFACTURER = "Power Plus Communications AG"

--- a/custom_components/ppc_smgw/translations/en.json
+++ b/custom_components/ppc_smgw/translations/en.json
@@ -26,7 +26,7 @@
     "options": {
       "step": {
         "user": {
-          "description": "If you need help with the configuration have a look here: https://github.com/jannickfahlbusch/ha-ppc-smgw",
+          "description": "If you need help with the configuration have a look here: {{repo_url}}",
           "data": {
             "name": "Display name",
             "host": "SMGW URL",


### PR DESCRIPTION
## Summary by Sourcery

Provide repository URL as a description placeholder in configuration flow forms to satisfy Home Assistant hassfest validation.

Bug Fixes:
- Add description placeholders with the repository URL to config flow forms that reference it, resolving hassfest validation errors.

Enhancements:
- Introduce a shared REPO_URL constant for reuse across the integration.