### PR TITLE
Fix scan interval

### DIFF
--- a/custom_components/ppc_smgw/__init__.py
+++ b/custom_components/ppc_smgw/__init__.py
@@ -37,16 +37,15 @@ async def async_setup_entry(
     entry: ConfigEntry,
 ) -> bool:
     """Set up this integration using UI."""
-    coordinator = SMGwDataUpdateCoordinator(
-        hass=hass,
-    )
-
-    global SCAN_INTERVAL
-    SCAN_INTERVAL = timedelta(
+    scan_interval = timedelta(
         minutes=entry.options.get(
             CONF_SCAN_INTERVAL,
             entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
         )
+    )
+    coordinator = SMGwDataUpdateCoordinator(
+        hass=hass,
+        update_interval=scan_interval,
     )
 
     development_mode = False

--- a/custom_components/ppc_smgw/__init__.py
+++ b/custom_components/ppc_smgw/__init__.py
@@ -129,8 +129,7 @@ async def async_reload_entry(
     entry: ConfigEntry,
 ) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):

--- a/custom_components/ppc_smgw/coordinator.py
+++ b/custom_components/ppc_smgw/coordinator.py
@@ -12,7 +12,6 @@ from .gateways.reading import Information
 
 
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(minutes=10)
 
 type ConfigEntry = ConfigEntry[Data]
 
@@ -23,9 +22,10 @@ class SMGwDataUpdateCoordinator(DataUpdateCoordinator[Information | None]):
     def __init__(
         self,
         hass: HomeAssistant,
+        update_interval: timedelta,
     ) -> None:
         super().__init__(
-            hass=hass, logger=_LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL
+            hass=hass, logger=_LOGGER, name=DOMAIN, update_interval=update_interval
         )
 
     async def _async_update_data(self) -> Information | None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 """Tests for PPC SMGW integration initialization - simplified version."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -98,9 +98,51 @@ class TestInit:
             # Verify the error message contains the host
             assert ppc_config_data["host"] in str(exc_info.value)
 
+    async def test_setup_entry_uses_configured_scan_interval(
+        self, hass: HomeAssistant, mock_gateway
+    ):
+        """Regression test for issue #94: coordinator must use the configured scan interval."""
+        custom_interval = 42
+        from custom_components.ppc_smgw.gateways.vendors import Vendor
+        from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+        from custom_components.ppc_smgw.const import CONF_METER_TYPE
+        config_data = {
+            CONF_METER_TYPE: Vendor.PPC,
+            CONF_HOST: "https://192.168.1.1",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_SCAN_INTERVAL: custom_interval,
+        }
+        entry = create_mock_config_entry(data=config_data)
 
-@pytest.mark.asyncio
-class TestCoordinator:
+        mock_integration = MagicMock()
+        mock_integration.domain = DOMAIN
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+
+        coordinator_cls = MagicMock(return_value=mock_coordinator)
+
+        with (
+            patch("custom_components.ppc_smgw.PPC_SMGW", return_value=mock_gateway),
+            patch("custom_components.ppc_smgw.create_async_httpx_client"),
+            patch(
+                "custom_components.ppc_smgw.async_get_loaded_integration",
+                return_value=mock_integration,
+            ),
+            patch.object(hass.config_entries, "async_forward_entry_setups"),
+            patch(
+                "custom_components.ppc_smgw.SMGwDataUpdateCoordinator",
+                coordinator_cls,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        coordinator_cls.assert_called_once_with(
+            hass=hass,
+            update_interval=timedelta(minutes=custom_interval),
+        )
+
+
     """Test the data update coordinator."""
 
     async def test_coordinator_fetches_data(
@@ -125,7 +167,7 @@ class TestCoordinator:
         )
         mock_gateway.get_data.return_value = mock_data
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass)
+        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,
@@ -145,7 +187,7 @@ class TestCoordinator:
 
         mock_gateway.get_data.side_effect = Exception("Connection error")
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass)
+        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,
@@ -166,7 +208,7 @@ class TestCoordinator:
         # Gateway returns invalid type (dict instead of Information)
         mock_gateway.get_data.return_value = {"invalid": "dict"}
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass)
+        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,
@@ -186,7 +228,7 @@ class TestCoordinator:
         # Gateway legitimately returns None (e.g. no data available yet)
         mock_gateway.get_data.return_value = None
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass)
+        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -197,7 +197,6 @@ class TestInit:
         )
 
 
-
 @pytest.mark.asyncio
 class TestCoordinator:
     """Test the data update coordinator."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,13 +8,25 @@ import pytz
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+
 from custom_components.ppc_smgw import async_setup_entry, async_unload_entry
-from custom_components.ppc_smgw.const import DOMAIN
+from custom_components.ppc_smgw.const import (
+    CONF_METER_TYPE,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from custom_components.ppc_smgw.coordinator import (
     SMGwDataUpdateCoordinator,
     Data,
 )
 from custom_components.ppc_smgw.gateways.reading import Information, Reading
+from custom_components.ppc_smgw.gateways.vendors import Vendor
 from tests.conftest import create_mock_config_entry
 
 
@@ -103,15 +115,6 @@ class TestInit:
     ):
         """Regression test for issue #94: coordinator must use the configured scan interval."""
         custom_interval = 42
-        from custom_components.ppc_smgw.gateways.vendors import Vendor
-        from homeassistant.const import (
-            CONF_HOST,
-            CONF_PASSWORD,
-            CONF_SCAN_INTERVAL,
-            CONF_USERNAME,
-        )
-        from custom_components.ppc_smgw.const import CONF_METER_TYPE
-
         config_data = {
             CONF_METER_TYPE: Vendor.PPC,
             CONF_HOST: "https://192.168.1.1",
@@ -148,6 +151,55 @@ class TestInit:
             update_interval=timedelta(minutes=custom_interval),
         )
 
+    async def test_setup_entry_options_override_data_scan_interval(
+        self, hass: HomeAssistant, mock_gateway
+    ):
+        """Regression test: entry.options scan_interval must take precedence over entry.data."""
+        data_interval = 5
+        options_interval = 99
+        config_data = {
+            CONF_METER_TYPE: Vendor.PPC,
+            CONF_HOST: "https://192.168.1.1",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_SCAN_INTERVAL: data_interval,
+        }
+        entry = create_mock_config_entry(
+            data=config_data,
+            options={CONF_SCAN_INTERVAL: options_interval},
+        )
+
+        mock_integration = MagicMock()
+        mock_integration.domain = DOMAIN
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+
+        coordinator_cls = MagicMock(return_value=mock_coordinator)
+
+        with (
+            patch("custom_components.ppc_smgw.PPC_SMGW", return_value=mock_gateway),
+            patch("custom_components.ppc_smgw.create_async_httpx_client"),
+            patch(
+                "custom_components.ppc_smgw.async_get_loaded_integration",
+                return_value=mock_integration,
+            ),
+            patch.object(hass.config_entries, "async_forward_entry_setups"),
+            patch(
+                "custom_components.ppc_smgw.SMGwDataUpdateCoordinator",
+                coordinator_cls,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        coordinator_cls.assert_called_once_with(
+            hass=hass,
+            update_interval=timedelta(minutes=options_interval),
+        )
+
+
+
+@pytest.mark.asyncio
+class TestCoordinator:
     """Test the data update coordinator."""
 
     async def test_coordinator_fetches_data(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -104,8 +104,14 @@ class TestInit:
         """Regression test for issue #94: coordinator must use the configured scan interval."""
         custom_interval = 42
         from custom_components.ppc_smgw.gateways.vendors import Vendor
-        from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+        from homeassistant.const import (
+            CONF_HOST,
+            CONF_PASSWORD,
+            CONF_SCAN_INTERVAL,
+            CONF_USERNAME,
+        )
         from custom_components.ppc_smgw.const import CONF_METER_TYPE
+
         config_data = {
             CONF_METER_TYPE: Vendor.PPC,
             CONF_HOST: "https://192.168.1.1",
@@ -142,7 +148,6 @@ class TestInit:
             update_interval=timedelta(minutes=custom_interval),
         )
 
-
     """Test the data update coordinator."""
 
     async def test_coordinator_fetches_data(
@@ -167,7 +172,9 @@ class TestInit:
         )
         mock_gateway.get_data.return_value = mock_data
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
+        coordinator = SMGwDataUpdateCoordinator(
+            hass=hass, update_interval=timedelta(minutes=5)
+        )
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,
@@ -187,7 +194,9 @@ class TestInit:
 
         mock_gateway.get_data.side_effect = Exception("Connection error")
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
+        coordinator = SMGwDataUpdateCoordinator(
+            hass=hass, update_interval=timedelta(minutes=5)
+        )
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,
@@ -208,7 +217,9 @@ class TestInit:
         # Gateway returns invalid type (dict instead of Information)
         mock_gateway.get_data.return_value = {"invalid": "dict"}
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
+        coordinator = SMGwDataUpdateCoordinator(
+            hass=hass, update_interval=timedelta(minutes=5)
+        )
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,
@@ -228,7 +239,9 @@ class TestInit:
         # Gateway legitimately returns None (e.g. no data available yet)
         mock_gateway.get_data.return_value = None
 
-        coordinator = SMGwDataUpdateCoordinator(hass=hass, update_interval=timedelta(minutes=5))
+        coordinator = SMGwDataUpdateCoordinator(
+            hass=hass, update_interval=timedelta(minutes=5)
+        )
         entry = create_mock_config_entry(data=ppc_config_data)
         entry.runtime_data = Data(
             client=mock_gateway,


### PR DESCRIPTION
Fixes #94

## Summary by Sourcery

Use the configuration-defined scan interval when scheduling data updates for the PPC SMGW coordinator instead of a hard-coded value.

Bug Fixes:
- Ensure the data update coordinator uses the scan interval from the config entry options/data rather than a module-level constant.

Enhancements:
- Pass the update interval explicitly into the data update coordinator instead of relying on a global SCAN_INTERVAL.

Tests:
- Add a regression test verifying that async_setup_entry wires the configured scan interval into the coordinator.
- Update coordinator tests to construct the coordinator with an explicit update interval.