### PR TITLE
feat: add automated release and alpha-release workflows

### DIFF
--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -1,0 +1,148 @@
+name: "Alpha Release"
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull Request number to build alpha from"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: alpha-release
+  cancel-in-progress: false
+
+jobs:
+  alpha-release:
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/build-alpha') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: React to comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Resolve PR context
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.eventName === 'issue_comment'
+              ? context.issue.number
+              : parseInt(context.payload.inputs.pr_number);
+
+            if (isNaN(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number: ${context.payload.inputs?.pr_number}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            core.setOutput('number', prNumber);
+            core.setOutput('sha', pr.head.sha);
+
+      - name: Checkout PR code
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Calculate alpha version
+        id: version
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          CURRENT=$(jq -r '.version' custom_components/ppc_smgw/manifest.json)
+          # Strip any existing pre-release suffix
+          BASE=$(echo "$CURRENT" | cut -d'-' -f1)
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+          NEXT_PATCH=$((PATCH + 1))
+
+          ALPHA="${MAJOR}.${MINOR}.${NEXT_PATCH}a${RUN_NUMBER}"
+          echo "alpha=$ALPHA" >> "$GITHUB_OUTPUT"
+          echo "Alpha version: $ALPHA"
+
+      - name: Update manifest.json
+        env:
+          ALPHA_VERSION: ${{ steps.version.outputs.alpha }}
+        run: |
+          tmp=$(mktemp)
+          jq --arg v "$ALPHA_VERSION" '.version = $v' \
+            custom_components/ppc_smgw/manifest.json > "$tmp"
+          [ -s "$tmp" ] || { echo "jq produced empty output"; exit 1; }
+          mv "$tmp" custom_components/ppc_smgw/manifest.json
+
+      - name: Create detached commit and tag
+        env:
+          ALPHA_VERSION: ${{ steps.version.outputs.alpha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add custom_components/ppc_smgw/manifest.json
+          git commit -m "chore: alpha release v${ALPHA_VERSION} [skip ci]"
+          git tag "v${ALPHA_VERSION}"
+          # Push only the tag — do NOT push to any branch
+          git push origin "v${ALPHA_VERSION}"
+
+      - name: Create GitHub Pre-Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALPHA_VERSION: ${{ steps.version.outputs.alpha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          gh release create "v${ALPHA_VERSION}" \
+            --title "Alpha: PR #${PR_NUMBER}" \
+            --notes "Alpha build from PR #${PR_NUMBER}." \
+            --prerelease
+
+      - name: React with success
+        if: success() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: React with failure
+        if: failure() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
+            });

--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -77,15 +77,16 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           CURRENT=$(jq -r '.version' custom_components/ppc_smgw/manifest.json)
-          # Strip any existing pre-release suffix
-          BASE=$(echo "$CURRENT" | cut -d'-' -f1)
+          # Strip any existing pre-release suffix (-alpha.x or aN.x)
+          BASE=$(echo "$CURRENT" | sed 's/[-a].*//')
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
           NEXT_PATCH=$((PATCH + 1))
 
-          ALPHA="${MAJOR}.${MINOR}.${NEXT_PATCH}a${RUN_NUMBER}"
+          ALPHA="${MAJOR}.${MINOR}.${NEXT_PATCH}a${RUN_NUMBER}.${RUN_ATTEMPT}"
           echo "alpha=$ALPHA" >> "$GITHUB_OUTPUT"
           echo "Alpha version: $ALPHA"
 
@@ -98,6 +99,9 @@ jobs:
             custom_components/ppc_smgw/manifest.json > "$tmp"
           [ -s "$tmp" ] || { echo "jq produced empty output"; exit 1; }
           mv "$tmp" custom_components/ppc_smgw/manifest.json
+
+      - name: Validate manifest.json
+        run: jq . custom_components/ppc_smgw/manifest.json > /dev/null
 
       - name: Create detached commit and tag
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,8 +38,8 @@ jobs:
           CURRENT=$(jq -r '.version' custom_components/ppc_smgw/manifest.json)
           echo "Current version: $CURRENT"
 
-          # Strip any existing pre-release suffix
-          BASE=$(echo "$CURRENT" | cut -d'-' -f1)
+          # Strip any existing pre-release suffix (-alpha.x or aN.x)
+          BASE=$(echo "$CURRENT" | sed 's/[-a].*//')
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
 
           case "$BUMP_TYPE" in

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,98 @@
+name: "Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Calculate new version
+        id: version
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+        run: |
+          CURRENT=$(jq -r '.version' custom_components/ppc_smgw/manifest.json)
+          echo "Current version: $CURRENT"
+
+          # Strip any existing pre-release suffix
+          BASE=$(echo "$CURRENT" | cut -d'-' -f1)
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+
+          case "$BUMP_TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW_VERSION"
+
+      - name: Update manifest.json
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          tmp=$(mktemp)
+          jq --arg v "$NEW_VERSION" '.version = $v' \
+            custom_components/ppc_smgw/manifest.json > "$tmp"
+          [ -s "$tmp" ] || { echo "jq produced empty output"; exit 1; }
+          mv "$tmp" custom_components/ppc_smgw/manifest.json
+
+      - name: Validate manifest.json
+        run: jq . custom_components/ppc_smgw/manifest.json > /dev/null
+
+      - name: Commit and tag
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add custom_components/ppc_smgw/manifest.json
+          git commit -m "chore: release v${NEW_VERSION} [skip ci]"
+          git tag "v${NEW_VERSION}"
+          git push origin main
+          git push origin "v${NEW_VERSION}"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          gh release create "v${NEW_VERSION}" \
+            --title "v${NEW_VERSION}" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
Add two GitHub Actions workflows for automated release management:

- release.yaml: production releases via workflow_dispatch with semver bump type selection (patch/minor/major). Bumps version in manifest.json, commits to main, tags, and creates a GitHub Release with auto-generated notes.

- alpha-release.yaml: pre-releases from PRs via /build-alpha ChatOps command or manual workflow_dispatch. Creates a detached tag with the alpha version in manifest.json without modifying the PR branch. HACS users with beta channel enabled can install these for testing.

## Summary by Sourcery

Add GitHub Actions workflows to automate production and alpha prerelease creation for the Home Assistant integration.

New Features:
- Introduce a manual production release workflow that bumps the manifest version, tags the release, pushes to main, and creates a GitHub Release.
- Add an alpha release workflow that can be triggered from PR comments or manually to build prerelease tags from pull request commits without modifying branches.

CI:
- Add release workflow with selectable semantic version bump type (patch/minor/major).
- Add alpha-release workflow that builds prereleases from pull requests and publishes them as GitHub prereleases with detached tags.