### PR TITLE
Fix/alpha release reactions

### DIFF
--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -12,8 +12,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
-  issues: write
+  pull-requests: write
 
 concurrency:
   group: alpha-release
@@ -31,19 +30,6 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     steps:
-      - name: React to comment
-        if: github.event_name == 'issue_comment'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
-
       - name: Resolve PR context
         id: pr
         uses: actions/github-script@v7
@@ -128,28 +114,27 @@ jobs:
             --notes "Alpha build from PR #${PR_NUMBER}." \
             --prerelease
 
-      - name: React with success
-        if: success() && github.event_name == 'issue_comment'
-        continue-on-error: true
+      - name: Comment on PR with release link
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket'
-            });
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const version = '${{ steps.version.outputs.alpha }}';
+            const success = '${{ job.status }}' === 'Success';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-      - name: React with failure
-        if: failure() && github.event_name == 'issue_comment'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
+            let body;
+            if (success) {
+              const releaseUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/releases/tag/v${version}`;
+              body = `**Alpha release \`v${version}\` published!**\n\nInstall via HACS (enable beta versions): [v${version}](${releaseUrl})`;
+            } else {
+              body = `**Alpha release failed.** See [workflow run](${runUrl}) for details.`;
+            }
+
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '-1'
+              issue_number: prNumber,
+              body: body
             });

--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - name: React to comment
         if: github.event_name == 'issue_comment'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -129,6 +130,7 @@ jobs:
 
       - name: React with success
         if: success() && github.event_name == 'issue_comment'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -141,6 +143,7 @@ jobs:
 
       - name: React with failure
         if: failure() && github.event_name == 'issue_comment'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary by Sourcery

Update the alpha release workflow to report release results via PR comments instead of reactions on issue comments.

New Features:
- Post a PR comment with the alpha release version and HACS install link when the workflow completes successfully.
- Post a PR comment with a link to the workflow run when the alpha release workflow fails.

Enhancements:
- Adjust GitHub workflow permissions to allow writing to pull requests and stop using issue-level permissions.