### PR TITLE
fix: correct job.status comparison to lowercase 'success'

### DIFF
--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -121,7 +121,7 @@ jobs:
           script: |
             const prNumber = ${{ steps.pr.outputs.number }};
             const version = '${{ steps.version.outputs.alpha }}';
-            const success = '${{ job.status }}' === 'Success';
+            const success = '${{ job.status }}' === 'success';
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
             let body;


### PR DESCRIPTION
job.status returns 'success' (lowercase) but the comparison used 'Success' (capitalized), causing the PR comment to always report failure even on successful builds.

## Summary by Sourcery

Bug Fixes:
- Correct job status comparison in the alpha release workflow so success is detected when job.status equals 'success' instead of 'Success'.