### PR TITLE
Fix/alpha comment status check

### DIFF
--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -73,7 +73,10 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
           NEXT_PATCH=$((PATCH + 1))
 
-          ALPHA="${MAJOR}.${MINOR}.${NEXT_PATCH}a${RUN_NUMBER}.${RUN_ATTEMPT}"
+          # Combine run_number and run_attempt into a single identifier
+          # to avoid tag collisions on reruns
+          ALPHA_NUM=$(( RUN_NUMBER * 10 + RUN_ATTEMPT ))
+          ALPHA="${MAJOR}.${MINOR}.${NEXT_PATCH}-alpha${ALPHA_NUM}"
           echo "alpha=$ALPHA" >> "$GITHUB_OUTPUT"
           echo "Alpha version: $ALPHA"
 

--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -121,7 +121,7 @@ jobs:
           script: |
             const prNumber = ${{ steps.pr.outputs.number }};
             const version = '${{ steps.version.outputs.alpha }}';
-            const success = '${{ job.status }}' === 'Success';
+            const success = '${{ job.status }}' === 'success';
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
             let body;


### PR DESCRIPTION
## Summary by Sourcery

Update alpha release workflow to produce unique alpha version tags per run and correct the job status check used for PR commenting.

Build:
- Change alpha version format to use a combined run and attempt identifier to avoid tag collisions on reruns.

CI:
- Fix PR comment script to compare against the correct lowercase job status value.