### PR TITLE
Fix malformed translation

### DIFF
--- a/custom_components/ppc_smgw/strings.json
+++ b/custom_components/ppc_smgw/strings.json
@@ -15,6 +15,21 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "options": {
+    "step": {
+      "user": {
+        "description": "If you need help with the configuration have a look here: {repo_url}",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+          "debug": "Development mode - DO NOT USE (Uses fake data)"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
     }

--- a/custom_components/ppc_smgw/translations/en.json
+++ b/custom_components/ppc_smgw/translations/en.json
@@ -26,7 +26,7 @@
     "options": {
       "step": {
         "user": {
-          "description": "If you need help with the configuration have a look here: {{repo_url}}",
+          "description": "If you need help with the configuration have a look here: {repo_url}",
           "data": {
             "name": "Display name",
             "host": "SMGW URL",


### PR DESCRIPTION
Fixes #92

## Summary by Sourcery

Bug Fixes:
- Fix invalid or malformed entries in the PPC SMGW strings and English translation files.