### PR TITLE
fix: make password optional in options flow

### DIFF
--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -47,6 +47,7 @@ def build_username_password_schema(
     default_username: str = "",
     default_scan_interval: int = DEFAULT_SCAN_INTERVAL,
     default_debug: bool = False,
+    optional_password: bool = False,
 ) -> vol.Schema:
     """Build a schema for username/password configuration.
 
@@ -57,19 +58,26 @@ def build_username_password_schema(
         default_username: Default value for the username field.
         default_scan_interval: Default value for the scan interval field.
         default_debug: Default value for the debug field (if allowed).
+        optional_password: If True, password can be left blank (for options flow).
 
     Returns:
         A voluptuous Schema for the configuration form.
     """
+    password_selector = TextSelector(
+        TextSelectorConfig(
+            type=TextSelectorType.PASSWORD, autocomplete="current-password"
+        )
+    )
+    if optional_password:
+        password_key = vol.Optional(CONF_PASSWORD, default="")
+    else:
+        password_key = vol.Required(CONF_PASSWORD)
+
     schema = {
         vol.Required(CONF_NAME, default=default_name): str,
         vol.Required(CONF_HOST, default=default_url): str,
         vol.Required(CONF_USERNAME, default=default_username): str,
-        vol.Required(CONF_PASSWORD): TextSelector(
-            TextSelectorConfig(
-                type=TextSelectorType.PASSWORD, autocomplete="current-password"
-            )
-        ),
+        password_key: password_selector,
         vol.Required(CONF_SCAN_INTERVAL, default=default_scan_interval): int,
     }
 
@@ -235,6 +243,9 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
         """Handle a flow initialized by the user."""
         self._errors = {}
         if user_input is not None:
+            # If password is blank, keep the existing one
+            if not user_input.get(CONF_PASSWORD):
+                user_input[CONF_PASSWORD] = self.data.get(CONF_PASSWORD, "")
             self.options.update(user_input)
             if self.data.get(CONF_HOST) != self.options.get(CONF_HOST) or self.data.get(
                 CONF_USERNAME
@@ -312,8 +323,16 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
             default_username=current_username,
             default_scan_interval=current_scan_interval,
             default_debug=current_debug,
+            optional_password=True,
         )
 
     def _update_options(self):
-        """Update config entry options."""
-        return self.async_create_entry(data=self.options)
+        """Update config entry data and close the options flow.
+
+        Merges all changed values into entry.data (the single source of truth
+        read by __init__.py). Options are kept empty to avoid dual-write
+        inconsistency.
+        """
+        new_data = {**self._config_entry.data, **self.options}
+        self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+        return self.async_create_entry(data={})

--- a/custom_components/ppc_smgw/strings.json
+++ b/custom_components/ppc_smgw/strings.json
@@ -26,6 +26,9 @@
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "debug": "Development mode - DO NOT USE (Uses fake data)"
+        },
+        "data_description": {
+          "password": "Leave blank to keep the current password"
         }
       }
     }

--- a/custom_components/ppc_smgw/translations/en.json
+++ b/custom_components/ppc_smgw/translations/en.json
@@ -34,6 +34,9 @@
             "password": "Password",
             "scan_interval": "Polling Interval in minutes",
             "debug": "Development mode - DO NOT USE (Uses fake data)"
+          },
+          "data_description": {
+            "password": "Leave blank to keep the current password"
           }
         }
       }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -157,6 +157,7 @@ class TestOptionsFlow:
         """Test that options flow successfully updates configuration."""
 
         entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
         options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
         options_flow.hass = hass
 
@@ -169,8 +170,52 @@ class TestOptionsFlow:
         )
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["data"]["scan_interval"] == 10
-        assert result["data"]["debug"] is True
+        # entry.data is the single source of truth
+        assert entry.data["scan_interval"] == 10
+        assert entry.data["debug"] is True
+
+    async def test_options_flow_blank_password_keeps_existing(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """Test that leaving the password blank preserves the existing one."""
+
+        entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        result = await options_flow.async_step_user(
+            user_input={
+                k: ppc_config_data[k]
+                for k in ["name", "host", "username", "scan_interval", "debug"]
+            }
+            | {CONF_PASSWORD: ""}
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data[CONF_PASSWORD] == ppc_config_data[CONF_PASSWORD]
+
+    async def test_options_flow_new_password_updates_entry_data(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """Test that providing a new password updates entry.data."""
+
+        entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        new_password = "new_secret_password"
+        result = await options_flow.async_step_user(
+            user_input={
+                k: ppc_config_data[k]
+                for k in ["name", "host", "username", "scan_interval", "debug"]
+            }
+            | {CONF_PASSWORD: new_password}
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data[CONF_PASSWORD] == new_password
 
     async def test_options_flow_rejects_duplicate_host_change(
         self, hass: HomeAssistant, ppc_config_data
@@ -178,6 +223,7 @@ class TestOptionsFlow:
         """Test that changing to duplicate host/username is rejected."""
 
         entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
         options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
         options_flow.hass = hass
 


### PR DESCRIPTION
## Summary by Sourcery

Make the options flow treat the password as optional while keeping configuration data in the config entry data as the single source of truth.

Bug Fixes:
- Ensure leaving the password blank in the options flow preserves the existing stored password.
- Prevent inconsistencies by updating config entry data directly instead of using options for runtime configuration.

Enhancements:
- Extend the username/password schema builder to support an optional password field for options flows.
- Adjust the options flow to merge changed fields into entry data and finalize with an empty options payload.

Tests:
- Expand options flow tests to cover blank-password behavior, new-password updates, and alignment with entry data as the source of truth.