### PR TITLE
EMH CASA: support multiple meters per gateway

### DIFF
--- a/custom_components/ppc_smgw/__init__.py
+++ b/custom_components/ppc_smgw/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.loader import async_get_loaded_integration
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, CONF_METER_TYPE
+from .gateways.emh.const import CONF_METER_ID as EMH_CONF_METER_ID
 from .coordinator import SMGwDataUpdateCoordinator, ConfigEntry, Data
 from custom_components.ppc_smgw.gateways.gateway import Gateway
 from custom_components.ppc_smgw.gateways.emh.emh import EMHGateway
@@ -87,6 +88,7 @@ async def async_setup_entry(
                 websession=create_async_httpx_client(hass, verify_ssl=False),
                 logger=_LOGGER,
                 debug=development_mode,
+                meter_id=entry.data.get(EMH_CONF_METER_ID) or None,
             )
         case _:
             _LOGGER.error(

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -199,8 +199,18 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             if self.data[CONF_METER_TYPE] == Vendor.EMH:
-                # Meter selection handled in the next step via gateway discovery
-                return await self.async_step_emh_meter_select()
+                if not await self._test_connection(
+                    self.data[CONF_HOST],
+                    self.data[CONF_USERNAME],
+                    self.data[CONF_PASSWORD],
+                ):
+                    _LOGGER.error(
+                        "Could not connect to SMGW at %s. Check connection manually",
+                        self.data[CONF_HOST],
+                    )
+                else:
+                    # Meter selection handled in the next step via gateway discovery
+                    return await self.async_step_emh_meter_select()
 
             if _host_username_combination_exists(
                 self.data[CONF_HOST],

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -286,9 +286,7 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "EMH meter discovery returned no results, creating entry with auto-detect"
             )
             self.data[emh_const.CONF_METER_ID] = ""
-            return self.async_create_entry(
-                title=self.data[CONF_NAME], data=self.data
-            )
+            return self.async_create_entry(title=self.data[CONF_NAME], data=self.data)
 
         options = [
             {"value": "", "label": "Auto-detect (first available)"},

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -13,7 +13,10 @@ from homeassistant.const import (
     CONF_DEBUG,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -185,9 +188,6 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             elif self.data[CONF_METER_TYPE] == Vendor("EMH"):
                 self.data[CONF_NAME] = user_input.get(CONF_NAME, emh_const.DEFAULT_NAME)
-                self.data[emh_const.CONF_METER_ID] = user_input.get(
-                    emh_const.CONF_METER_ID, ""
-                )
             else:
                 self.data[CONF_NAME] = user_input.get(CONF_NAME, ppc_const.DEFAULT_NAME)
                 self.data[CONF_DEBUG] = user_input.get(CONF_DEBUG, DEFAULT_DEBUG)
@@ -197,6 +197,10 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.data[CONF_SCAN_INTERVAL] = user_input.get(
                 CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
             )
+
+            if self.data[CONF_METER_TYPE] == Vendor.EMH:
+                # Meter selection handled in the next step via gateway discovery
+                return await self.async_step_emh_meter_select()
 
             if _host_username_combination_exists(
                 self.data[CONF_HOST],
@@ -229,7 +233,7 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         elif self.data[CONF_METER_TYPE] == Vendor.EMH:
             data_schema = build_username_password_schema(
-                emh_const.DEFAULT_NAME, emh_const.URL, default_meter_id=""
+                emh_const.DEFAULT_NAME, emh_const.URL
             )
 
         return self.async_show_form(
@@ -237,6 +241,70 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             last_step=True,
             errors=self._errors,
+            description_placeholders={"repo_url": REPO_URL},
+        )
+
+    async def _discover_emh_meter_ids(self) -> list[str]:
+        """Call the EMH gateway and return all available meter IDs."""
+        from .gateways.emh.emhcasa.emh_client import EMHCasaClient
+
+        client = EMHCasaClient(
+            base_url=self.data[CONF_HOST],
+            username=self.data[CONF_USERNAME],
+            password=self.data[CONF_PASSWORD],
+            httpx_client=create_async_httpx_client(self.hass, verify_ssl=False),
+            logger=_LOGGER,
+        )
+        return await client.discover_all_meter_ids()
+
+    async def async_step_emh_meter_select(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Let the user pick which EMH meter to monitor."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            meter_id = user_input.get(emh_const.CONF_METER_ID, "")
+            self.data[emh_const.CONF_METER_ID] = meter_id
+
+            if _host_username_combination_exists(
+                self.data[CONF_HOST],
+                self.data[CONF_USERNAME],
+                self.hass,
+                meter_id=meter_id,
+            ):
+                errors[emh_const.CONF_METER_ID] = "already_configured"
+            else:
+                return self.async_create_entry(
+                    title=self.data[CONF_NAME], data=self.data
+                )
+
+        meter_ids = await self._discover_emh_meter_ids()
+
+        if not meter_ids:
+            _LOGGER.warning(
+                "EMH meter discovery returned no results, creating entry with auto-detect"
+            )
+            self.data[emh_const.CONF_METER_ID] = ""
+            return self.async_create_entry(
+                title=self.data[CONF_NAME], data=self.data
+            )
+
+        options = [
+            {"value": "", "label": "Auto-detect (first available)"},
+            *[{"value": m, "label": m} for m in meter_ids],
+        ]
+
+        return self.async_show_form(
+            step_id="emh_meter_select",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(emh_const.CONF_METER_ID, default=""): SelectSelector(
+                        SelectSelectorConfig(options=options)
+                    )
+                }
+            ),
+            errors=errors,
             description_placeholders={"repo_url": REPO_URL},
         )
 

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -48,6 +48,7 @@ def build_username_password_schema(
     default_scan_interval: int = DEFAULT_SCAN_INTERVAL,
     default_debug: bool = False,
     optional_password: bool = False,
+    default_meter_id: str | None = None,
 ) -> vol.Schema:
     """Build a schema for username/password configuration.
 
@@ -59,6 +60,7 @@ def build_username_password_schema(
         default_scan_interval: Default value for the scan interval field.
         default_debug: Default value for the debug field (if allowed).
         optional_password: If True, password can be left blank (for options flow).
+        default_meter_id: If not None, include an optional meter_id field (EMH only).
 
     Returns:
         A voluptuous Schema for the configuration form.
@@ -84,19 +86,30 @@ def build_username_password_schema(
     if allow_debugging:
         schema[vol.Optional(CONF_DEBUG, default=default_debug)] = bool
 
+    if default_meter_id is not None:
+        schema[vol.Optional(emh_const.CONF_METER_ID, default=default_meter_id)] = str
+
     return vol.Schema(schema)
 
 
 def _host_username_combination_exists(
-    host: str, username: str, hass: HomeAssistant, exclude_entry_id: str | None = None
+    host: str,
+    username: str,
+    hass: HomeAssistant,
+    exclude_entry_id: str | None = None,
+    meter_id: str = "",
 ) -> bool:
-    """Check if the combination of host and username already exists in configuration.
+    """Check if the combination of host, username (and meter_id) already exists.
+
+    For EMH entries, meter_id is part of the unique key so that multiple instances
+    of the same gateway with different meters are allowed.
 
     Args:
         host: The host/URL to check.
         username: The username to check.
         hass: Home Assistant instance.
         exclude_entry_id: Optional entry ID to exclude from the check (for updates).
+        meter_id: Meter ID to include in the uniqueness check (EMH only, default "").
 
     Returns:
         True if the combination exists (excluding the specified entry), False otherwise.
@@ -113,7 +126,9 @@ def _host_username_combination_exists(
         )
 
         if entry_host == host and entry_username == username:
-            return True
+            entry_meter_id = entry.data.get(emh_const.CONF_METER_ID, "")
+            if entry_meter_id == meter_id:
+                return True
 
     return False
 
@@ -170,6 +185,9 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             elif self.data[CONF_METER_TYPE] == Vendor("EMH"):
                 self.data[CONF_NAME] = user_input.get(CONF_NAME, emh_const.DEFAULT_NAME)
+                self.data[emh_const.CONF_METER_ID] = user_input.get(
+                    emh_const.CONF_METER_ID, ""
+                )
             else:
                 self.data[CONF_NAME] = user_input.get(CONF_NAME, ppc_const.DEFAULT_NAME)
                 self.data[CONF_DEBUG] = user_input.get(CONF_DEBUG, DEFAULT_DEBUG)
@@ -181,7 +199,10 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             if _host_username_combination_exists(
-                self.data[CONF_HOST], self.data[CONF_USERNAME], self.hass
+                self.data[CONF_HOST],
+                self.data[CONF_USERNAME],
+                self.hass,
+                meter_id=self.data.get(emh_const.CONF_METER_ID, ""),
             ):
                 self._errors[CONF_HOST] = "already_configured"
             elif await self._test_connection(
@@ -208,7 +229,7 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         elif self.data[CONF_METER_TYPE] == Vendor.EMH:
             data_schema = build_username_password_schema(
-                emh_const.DEFAULT_NAME, emh_const.URL
+                emh_const.DEFAULT_NAME, emh_const.URL, default_meter_id=""
             )
 
         return self.async_show_form(
@@ -256,6 +277,7 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
                     self.options.get(CONF_USERNAME),
                     self.hass,
                     exclude_entry_id=self._config_entry.entry_id,
+                    meter_id=self.options.get(emh_const.CONF_METER_ID, ""),
                 ):
                     self._errors[CONF_HOST] = "already_configured"
                 else:
@@ -316,6 +338,14 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_DEBUG, self.data.get(CONF_DEBUG, DEFAULT_DEBUG)
             )
 
+        # For EMH, include the meter_id field
+        is_emh = vendor == Vendor.EMH
+        current_meter_id = None
+        if is_emh:
+            current_meter_id = self.options.get(
+                emh_const.CONF_METER_ID, self.data.get(emh_const.CONF_METER_ID, "")
+            )
+
         return build_username_password_schema(
             default_name=current_name,
             default_url=current_host,
@@ -324,6 +354,7 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
             default_scan_interval=current_scan_interval,
             default_debug=current_debug,
             optional_password=True,
+            default_meter_id=current_meter_id,
         )
 
     def _update_options(self):

--- a/custom_components/ppc_smgw/gateways/emh/const.py
+++ b/custom_components/ppc_smgw/gateways/emh/const.py
@@ -3,3 +3,5 @@ DEFAULT_NAME = "EMH SMGW"
 MANUFACTURER = "EMH metering GmbH & Co. KG"
 URL = "https://{{INSERT_IP}}"
 DEFAULT_URL = URL
+
+CONF_METER_ID = "meter_id"

--- a/custom_components/ppc_smgw/gateways/emh/emh.py
+++ b/custom_components/ppc_smgw/gateways/emh/emh.py
@@ -23,6 +23,7 @@ class EMHGateway(Gateway):
         websession: httpx.AsyncClient,
         logger: logging.Logger,
         debug: bool = False,
+        meter_id: str | None = None,
     ) -> None:
         super().__init__(host, username, password, websession, logger, debug)
 
@@ -32,6 +33,7 @@ class EMHGateway(Gateway):
             password=password,
             httpx_client=websession,
             logger=logger,
+            meter_id=meter_id,
         )
 
     async def get_data(self) -> Information:

--- a/custom_components/ppc_smgw/gateways/emh/emhcasa/emh_client.py
+++ b/custom_components/ppc_smgw/gateways/emh/emhcasa/emh_client.py
@@ -49,43 +49,32 @@ class EMHCasaClient:
 
         return information
 
-    async def _discover_meter_id(self) -> str | None:
-        self.logger.debug(f"Discovering meter ID from {self.base_url}")
+    async def discover_all_meter_ids(self) -> list[str]:
+        """Return all meter IDs available on this gateway via /json/metering/origin/."""
+        self.logger.debug(f"Discovering all meter IDs from {self.base_url}")
 
         try:
             response = await self.httpx_client.get(
-                f"{self.base_url}/json/metering/derived",
+                f"{self.base_url}/json/metering/origin/",
                 auth=self._get_auth(),
                 timeout=10,
             )
             self.logger.debug(
-                f"Got contract list: \nStatus code: {response.status_code}\nRaw response: {response.text}"
+                f"Got meter list: \nStatus code: {response.status_code}\nRaw response: {response.text}"
             )
-            contract_ids = response.json()
+            meter_ids: list[str] = response.json()
         except Exception as e:
-            self.logger.error(f"Failed to fetch contract list: {e}")
-            return None
+            self.logger.error(f"Failed to fetch meter list: {e}")
+            return []
 
-        for contract_id in contract_ids:
-            try:
-                response = await self.httpx_client.get(
-                    f"{self.base_url}/json/metering/derived/{contract_id}",
-                    auth=self._get_auth(),
-                    timeout=10,
-                )
-                contract = response.json()
-                self.logger.debug(f"Contract {contract_id}: {contract}")
+        self.logger.debug(f"Discovered meter IDs: {meter_ids}")
+        return meter_ids
 
-                sensor_domains = contract.get("sensor_domains", [])
-                if sensor_domains:
-                    self.logger.debug(
-                        f"Found meter ID: {sensor_domains[0]} from contract {contract_id}"
-                    )
-                    return sensor_domains[0]
-            except Exception as e:
-                self.logger.error(f"Failed to fetch contract {contract_id}: {e}")
-
-        self.logger.error("No meter ID found in any contract")
+    async def _discover_meter_id(self) -> str | None:
+        meter_ids = await self.discover_all_meter_ids()
+        if meter_ids:
+            return meter_ids[0]
+        self.logger.error("No meter ID found")
         return None
 
     async def _get_readings(self) -> dict[OBISCode, Reading]:

--- a/custom_components/ppc_smgw/gateways/emh/emhcasa/emh_client.py
+++ b/custom_components/ppc_smgw/gateways/emh/emhcasa/emh_client.py
@@ -15,6 +15,7 @@ class EMHCasaClient:
         password: str,
         httpx_client: httpx.AsyncClient,
         logger,
+        meter_id: str | None = None,
     ):
         if not base_url.startswith(("http://", "https://")):
             base_url = f"https://{base_url}"
@@ -23,7 +24,7 @@ class EMHCasaClient:
         self.base_url = base_url
         self.username = username
         self.password = password
-        self.meter_id: str | None = None
+        self.meter_id: str | None = meter_id or None
 
         self.httpx_client = httpx_client
         self.logger = logger

--- a/custom_components/ppc_smgw/strings.json
+++ b/custom_components/ppc_smgw/strings.json
@@ -9,6 +9,11 @@
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]"
         }
+      },
+      "emh_meter_select": {
+        "data": {
+          "meter_id": "Meter"
+        }
       }
     },
     "abort": {
@@ -25,7 +30,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-          "debug": "Development mode - DO NOT USE (Uses fake data)"
+          "debug": "Development mode - DO NOT USE (Uses fake data)",
+          "meter_id": "Meter ID (EMH only — leave blank for auto-detect)"
         },
         "data_description": {
           "password": "Leave blank to keep the current password"

--- a/custom_components/ppc_smgw/translations/en.json
+++ b/custom_components/ppc_smgw/translations/en.json
@@ -20,6 +20,12 @@
             "scan_interval": "Polling Interval in minutes",
             "debug": "Development mode - DO NOT USE (Uses fake data)"
           }
+        },
+        "emh_meter_select": {
+          "description": "Select the meter to monitor. Choose 'Auto-detect' to use the first meter found, or pick a specific meter ID if you have multiple meters behind this gateway.",
+          "data": {
+            "meter_id": "Meter"
+          }
         }
       }
     },
@@ -33,7 +39,8 @@
             "username": "Username",
             "password": "Password",
             "scan_interval": "Polling Interval in minutes",
-            "debug": "Development mode - DO NOT USE (Uses fake data)"
+            "debug": "Development mode - DO NOT USE (Uses fake data)",
+            "meter_id": "Meter ID (EMH only — leave blank for auto-detect)"
           },
           "data_description": {
             "password": "Leave blank to keep the current password"

--- a/scripts/test_emh_local.py
+++ b/scripts/test_emh_local.py
@@ -6,11 +6,14 @@ Requirements:  pip install httpx
 
 Usage:
     source .venv/bin/activate
-    python scripts/test_emh_local.py <host> <username> <password>
+    python scripts/test_emh_local.py <host> <username> <password> [meter_id]
 
-Example:
-    source .venv/bin/activate
+Examples:
+    # Auto-discover meter and read data
     python scripts/test_emh_local.py https://192.168.33.2 admin secret
+
+    # Use a specific meter ID
+    python scripts/test_emh_local.py https://192.168.33.2 admin secret 1emh1234567890
 """
 
 import asyncio
@@ -121,7 +124,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("emh_test")
 
 
-async def main(host: str, username: str, password: str) -> None:
+async def main(host: str, username: str, password: str, meter_id: str = "") -> None:
     import httpx
 
     async with httpx.AsyncClient(verify=False) as client:
@@ -131,12 +134,20 @@ async def main(host: str, username: str, password: str) -> None:
             password=password,
             httpx_client=client,
             logger=logger,
+            meter_id=meter_id or None,
         )
+
+        print("\n=== Meter discovery (/json/metering/origin/) ===")
+        meter_ids = await emh.discover_all_meter_ids()
+        if meter_ids:
+            for m in meter_ids:
+                print(f"  {m}")
+        else:
+            print("  (none found)")
+
+        print(f"\n=== Readings (meter_id={meter_id or 'auto-detect'}) ===")
         info = await emh.get_data()
-        print("\n=== Result ===")
         print(f"Name:     {info.name}")
-        print(f"Model:    {info.model}")
-        print(f"Firmware: {info.firmware_version}")
         print(f"Updated:  {info.last_update}")
         print(f"Readings ({len(info.readings)}):")
         for obis, reading in info.readings.items():
@@ -144,7 +155,8 @@ async def main(host: str, username: str, password: str) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
+    if len(sys.argv) not in (4, 5):
         print(__doc__)
         sys.exit(1)
-    asyncio.run(main(sys.argv[1], sys.argv[2], sys.argv[3]))
+    meter_id = sys.argv[4] if len(sys.argv) == 5 else ""
+    asyncio.run(main(sys.argv[1], sys.argv[2], sys.argv[3], meter_id))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from homeassistant import config_entries
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -40,29 +40,17 @@ def create_mock_config_entry(
     data: dict,
     entry_id: str = "test_entry_id",
     options: dict | None = None,
-) -> config_entries.ConfigEntry:
-    """Factory function to create ConfigEntry objects for testing.
-
-    Args:
-        data: Configuration data for the entry
-        entry_id: Unique identifier for the entry (default: "test_entry_id")
-        options: Optional options dictionary (default: empty dict)
-
-    Returns:
-        A properly configured ConfigEntry for testing
-    """
-    return config_entries.ConfigEntry(
+) -> MockConfigEntry:
+    """Factory function to create ConfigEntry objects for testing."""
+    return MockConfigEntry(
         version=2,
         minor_version=2,
         domain=DOMAIN,
         title=data.get(CONF_NAME, "Test Entry"),
         data=data,
-        source=config_entries.SOURCE_USER,
         entry_id=entry_id,
-        discovery_keys={},
         options=options or {},
         unique_id=None,
-        subentries_data={},
     )
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -89,7 +89,9 @@ class TestConfigFlow:
 
         with (
             patch.object(flow, "_test_connection", return_value=True),
-            patch.object(flow, "_discover_emh_meter_ids", return_value=["1test000000001"]),
+            patch.object(
+                flow, "_discover_emh_meter_ids", return_value=["1test000000001"]
+            ),
         ):
             result = await flow.async_step_connection_info(user_input=user_input)
 
@@ -110,7 +112,9 @@ class TestConfigFlow:
         flow.hass = hass
         flow.data = {**emh_config_data}
 
-        with patch.object(flow, "_discover_emh_meter_ids", return_value=["1test000000001"]):
+        with patch.object(
+            flow, "_discover_emh_meter_ids", return_value=["1test000000001"]
+        ):
             result = await flow.async_step_emh_meter_select(
                 user_input={CONF_METER_ID: "1test000000001"}
             )
@@ -229,7 +233,13 @@ class TestConfigFlow:
             result = await flow.async_step_connection_info(
                 user_input={
                     k: emh_config_data[k]
-                    for k in [CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL]
+                    for k in [
+                        CONF_NAME,
+                        CONF_HOST,
+                        CONF_USERNAME,
+                        CONF_PASSWORD,
+                        CONF_SCAN_INTERVAL,
+                    ]
                 }
             )
 
@@ -247,7 +257,9 @@ class TestConfigFlow:
         flow.data = {**emh_config_data}
 
         with (
-            patch.object(flow, "_discover_emh_meter_ids", return_value=["1test000000001"]),
+            patch.object(
+                flow, "_discover_emh_meter_ids", return_value=["1test000000001"]
+            ),
             patch(
                 "custom_components.ppc_smgw.config_flow._host_username_combination_exists",
                 return_value=True,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -65,7 +65,11 @@ class TestConfigFlow:
     async def test_connection_info_creates_entry(
         self, hass: HomeAssistant, vendor, vendor_config_data, vendor_expected_name
     ):
-        """Test that valid connection info creates entry (parametrized for all vendors)."""
+        """Test that valid connection info creates entry (parametrized for all vendors).
+
+        For EMH the flow proceeds to the meter-select step instead of creating
+        the entry immediately, so we assert FORM + correct step_id there.
+        """
         flow = PPC_SMGLocalConfigFlow()
         flow.hass = hass
         flow.data = {CONF_METER_TYPE: vendor}
@@ -83,11 +87,75 @@ class TestConfigFlow:
         if CONF_DEBUG in vendor_config_data:
             user_input[CONF_DEBUG] = vendor_config_data[CONF_DEBUG]
 
-        with patch.object(flow, "_test_connection", return_value=True):
+        with (
+            patch.object(flow, "_test_connection", return_value=True),
+            patch.object(flow, "_discover_emh_meter_ids", return_value=["1test000000001"]),
+        ):
             result = await flow.async_step_connection_info(user_input=user_input)
 
+        if vendor == Vendor.EMH:
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "emh_meter_select"
+        else:
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+            assert result["title"] == vendor_expected_name
+
+    async def test_emh_meter_select_creates_entry(
+        self, hass: HomeAssistant, emh_config_data
+    ):
+        """Test that selecting a meter in the EMH meter-select step creates the entry."""
+        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
+
+        flow = PPC_SMGLocalConfigFlow()
+        flow.hass = hass
+        flow.data = {**emh_config_data}
+
+        with patch.object(flow, "_discover_emh_meter_ids", return_value=["1test000000001"]):
+            result = await flow.async_step_emh_meter_select(
+                user_input={CONF_METER_ID: "1test000000001"}
+            )
+
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == vendor_expected_name
+        assert result["title"] == emh_config_data[CONF_NAME]
+        assert result["data"][CONF_METER_ID] == "1test000000001"
+
+    async def test_emh_meter_select_shows_all_discovered_meters(
+        self, hass: HomeAssistant, emh_config_data
+    ):
+        """Test that the meter-select form lists all meters discovered on the gateway."""
+        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
+
+        flow = PPC_SMGLocalConfigFlow()
+        flow.hass = hass
+        flow.data = {**emh_config_data}
+
+        meter_ids = ["1test000000001", "1test000000002", "1test000000003"]
+        with patch.object(flow, "_discover_emh_meter_ids", return_value=meter_ids):
+            result = await flow.async_step_emh_meter_select(user_input=None)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "emh_meter_select"
+        schema = result["data_schema"].schema
+        selector = schema[next(k for k in schema if k.schema == CONF_METER_ID)]
+        option_values = [o["value"] for o in selector.config["options"]]
+        assert "" in option_values  # auto-detect
+        assert all(m in option_values for m in meter_ids)
+
+    async def test_emh_meter_select_auto_detect_on_no_meters(
+        self, hass: HomeAssistant, emh_config_data
+    ):
+        """Test that discovery failure falls back to auto-detect and creates the entry."""
+        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
+
+        flow = PPC_SMGLocalConfigFlow()
+        flow.hass = hass
+        flow.data = {**emh_config_data}
+
+        with patch.object(flow, "_discover_emh_meter_ids", return_value=[]):
+            result = await flow.async_step_emh_meter_select(user_input=None)
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_METER_ID] == ""
 
     async def test_duplicate_host_username_rejected(
         self, hass: HomeAssistant, ppc_config_data

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -119,10 +119,10 @@ class TestConfigFlow:
         assert result["title"] == emh_config_data[CONF_NAME]
         assert result["data"][CONF_METER_ID] == "1test000000001"
 
-    async def test_emh_meter_select_shows_all_discovered_meters(
+    async def test_emh_meter_select_shows_form_for_multiple_meters(
         self, hass: HomeAssistant, emh_config_data
     ):
-        """Test that the meter-select form lists all meters discovered on the gateway."""
+        """Test that the meter-select step shows a form when multiple meters are found."""
         from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
 
         flow = PPC_SMGLocalConfigFlow()
@@ -135,11 +135,14 @@ class TestConfigFlow:
 
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "emh_meter_select"
-        schema = result["data_schema"].schema
-        selector = schema[next(k for k in schema if k.schema == CONF_METER_ID)]
-        option_values = [o["value"] for o in selector.config["options"]]
-        assert "" in option_values  # auto-detect
-        assert all(m in option_values for m in meter_ids)
+
+        # Verify any of the discovered meters can be selected
+        with patch.object(flow, "_discover_emh_meter_ids", return_value=meter_ids):
+            result = await flow.async_step_emh_meter_select(
+                user_input={CONF_METER_ID: "1test000000002"}
+            )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_METER_ID] == "1test000000002"
 
     async def test_emh_meter_select_auto_detect_on_no_meters(
         self, hass: HomeAssistant, emh_config_data
@@ -213,6 +216,50 @@ class TestConfigFlow:
 
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "connection_info"
+
+    async def test_emh_connection_failure_shows_form_again(
+        self, hass: HomeAssistant, emh_config_data
+    ):
+        """Test that a failed connection test for EMH shows the form again."""
+        flow = PPC_SMGLocalConfigFlow()
+        flow.hass = hass
+        flow.data = {CONF_METER_TYPE: Vendor.EMH}
+
+        with patch.object(flow, "_test_connection", return_value=False):
+            result = await flow.async_step_connection_info(
+                user_input={
+                    k: emh_config_data[k]
+                    for k in [CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL]
+                }
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "connection_info"
+
+    async def test_emh_meter_select_rejects_duplicate_meter(
+        self, hass: HomeAssistant, emh_config_data
+    ):
+        """Test that selecting an already-configured meter shows an error."""
+        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
+
+        flow = PPC_SMGLocalConfigFlow()
+        flow.hass = hass
+        flow.data = {**emh_config_data}
+
+        with (
+            patch.object(flow, "_discover_emh_meter_ids", return_value=["1test000000001"]),
+            patch(
+                "custom_components.ppc_smgw.config_flow._host_username_combination_exists",
+                return_value=True,
+            ),
+        ):
+            result = await flow.async_step_emh_meter_select(
+                user_input={CONF_METER_ID: "1test000000001"}
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "emh_meter_select"
+        assert CONF_METER_ID in result["errors"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_emh_client.py
+++ b/tests/test_emh_client.py
@@ -12,26 +12,6 @@ from custom_components.ppc_smgw.gateways.emh.emhcasa.emh_client import EMHCasaCl
 # Anonymised fixture data matching real device response shapes
 # ---------------------------------------------------------------------------
 
-_CONTRACT_ID = "0100aabbccdd00.test_contract_taf01000014000000000001.sm"
-
-_DERIVED_LIST = [_CONTRACT_ID]
-
-_DERIVED_CONTRACT = {
-    "active_tariff": -1,
-    "capture_period": 900,
-    "emt_channel_name": "testp01100001v3",
-    "logical_name": _CONTRACT_ID,
-    "metering_point_id": "DE0000000000000000000000000000001",
-    "sensor_domains": ["1test000000001"],
-    "taf_identifier": "test_contract_taf01000014000000000001.sm",
-    "taf_name": "test_contract_taf01000014000000000001",
-    "taf_state": "archive",
-    "taf_type": "TAF-1",
-    "user_domain": "0000000000000000000001",
-    "validity_end": 1762124400,
-    "validity_start": 1759984200,
-}
-
 _METER_ID = "1test000000001"
 
 _ORIGIN_EXTENDED = {
@@ -157,28 +137,6 @@ class TestDiscoverAllMeterIds:
         assert meter_ids == []
 
 
-class TestDiscoverMeterId:
-    async def test_returns_first_meter(self):
-        c = _make_client()
-        c.httpx_client.get = AsyncMock(
-            return_value=_make_response([_METER_ID, "1test000000002"])
-        )
-        meter_id = await c._discover_meter_id()
-        assert meter_id == _METER_ID
-
-    async def test_returns_none_on_connection_error(self):
-        c = _make_client()
-        c.httpx_client.get = AsyncMock(side_effect=Exception("connection refused"))
-        meter_id = await c._discover_meter_id()
-        assert meter_id is None
-
-    async def test_returns_none_when_no_meters(self):
-        c = _make_client()
-        c.httpx_client.get = AsyncMock(return_value=_make_response([]))
-        meter_id = await c._discover_meter_id()
-        assert meter_id is None
-
-
 # ---------------------------------------------------------------------------
 # _get_readings / get_data
 # ---------------------------------------------------------------------------
@@ -199,15 +157,12 @@ class TestGetReadings:
         assert "1-0:2.8.0" in readings
         assert "1-0:16.7.0" in readings
 
-    def test_import_value_converted_from_wh_to_kwh(self):
+    async def test_import_value_converted_from_wh_to_kwh(self):
         """value=12345678, scaler=-1, unit=30 → 12345678 * 0.1 / 1000 = 1234.5678"""
         c = _make_client()
         c.meter_id = _METER_ID
         c.httpx_client.get = AsyncMock(return_value=_make_response(_ORIGIN_EXTENDED))
-
-        import asyncio
-
-        readings = asyncio.get_event_loop().run_until_complete(c._get_readings())
+        readings = await c._get_readings()
         assert readings["1-0:1.8.0"].value == pytest.approx(1234.5678)
 
     async def test_skips_invalid_logical_name(self):

--- a/tests/test_emh_client.py
+++ b/tests/test_emh_client.py
@@ -135,14 +135,33 @@ class TestBaseUrlNormalisation:
 # ---------------------------------------------------------------------------
 
 
-class TestDiscoverMeterId:
-    async def test_returns_first_sensor_domain(self):
+class TestDiscoverAllMeterIds:
+    async def test_returns_all_meter_ids(self):
         c = _make_client()
         c.httpx_client.get = AsyncMock(
-            side_effect=[
-                _make_response(_DERIVED_LIST),
-                _make_response(_DERIVED_CONTRACT),
-            ]
+            return_value=_make_response([_METER_ID, "1test000000002"])
+        )
+        meter_ids = await c.discover_all_meter_ids()
+        assert meter_ids == [_METER_ID, "1test000000002"]
+
+    async def test_returns_empty_on_connection_error(self):
+        c = _make_client()
+        c.httpx_client.get = AsyncMock(side_effect=Exception("connection refused"))
+        meter_ids = await c.discover_all_meter_ids()
+        assert meter_ids == []
+
+    async def test_returns_empty_when_no_meters(self):
+        c = _make_client()
+        c.httpx_client.get = AsyncMock(return_value=_make_response([]))
+        meter_ids = await c.discover_all_meter_ids()
+        assert meter_ids == []
+
+
+class TestDiscoverMeterId:
+    async def test_returns_first_meter(self):
+        c = _make_client()
+        c.httpx_client.get = AsyncMock(
+            return_value=_make_response([_METER_ID, "1test000000002"])
         )
         meter_id = await c._discover_meter_id()
         assert meter_id == _METER_ID
@@ -153,15 +172,9 @@ class TestDiscoverMeterId:
         meter_id = await c._discover_meter_id()
         assert meter_id is None
 
-    async def test_returns_none_when_no_sensor_domains(self):
-        contract_without_domains = {**_DERIVED_CONTRACT, "sensor_domains": []}
+    async def test_returns_none_when_no_meters(self):
         c = _make_client()
-        c.httpx_client.get = AsyncMock(
-            side_effect=[
-                _make_response(_DERIVED_LIST),
-                _make_response(contract_without_domains),
-            ]
-        )
+        c.httpx_client.get = AsyncMock(return_value=_make_response([]))
         meter_id = await c._discover_meter_id()
         assert meter_id is None
 
@@ -176,8 +189,7 @@ class TestGetReadings:
         c = _make_client()
         c.httpx_client.get = AsyncMock(
             side_effect=[
-                _make_response(_DERIVED_LIST),
-                _make_response(_DERIVED_CONTRACT),
+                _make_response([_METER_ID]),
                 _make_response(_ORIGIN_EXTENDED),
             ]
         )
@@ -218,8 +230,7 @@ class TestGetReadings:
         c = _make_client()
         c.httpx_client.get = AsyncMock(
             side_effect=[
-                _make_response(_DERIVED_LIST),
-                _make_response(_DERIVED_CONTRACT),
+                _make_response([_METER_ID]),
                 _make_response(_ORIGIN_EXTENDED),
             ]
         )


### PR DESCRIPTION
Adds support for multiple physical meters behind a single EMH CASA gateway.                                                                                                           
   
During setup, the integration queries /json/metering/origin/ and presents all discovered meter IDs in a dropdown. The user selects one meter per config entry; add the integration again to monitor additional meters.                       
                                                                                                                                                                                        
  - Gateway discovery uses the direct /json/metering/origin/ endpoint instead of iterating contracts                                                                                    
  - Optional meter_id config field; leave blank for auto-detect (backward compatible)
  - Uniqueness check updated to host + username + meter_id so the same gateway can be added multiple times with different meters                                                        
  - meter_id exposed in options flow for post-setup changes 

fixes #101

## Summary by Sourcery

Add support for selecting and managing multiple EMH CASA meters behind a single gateway, including discovery-based meter selection and updated uniqueness handling.

New Features:
- Allow users to select a specific EMH meter ID discovered from the gateway during config flow and via options after setup.
- Support multiple EMH CASA config entries for the same gateway by treating meter_id as part of the unique key.

Enhancements:
- Simplify EMH meter discovery by querying the /json/metering/origin/ endpoint and using the first result for auto-detection.
- Expose an optional meter_id configuration field for EMH entries and propagate it through to the EMH client and gateway handling.
- Extend the local EMH test script to accept an optional meter_id argument and display discovered meters.

Tests:
- Add tests for discovering all EMH meter IDs directly from the gateway and update existing tests to cover the new discovery behavior.