### PR TITLE
Fix HACS repository link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ha-ppc-smgw
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jannickfahlbusch&repository=ha-ppc-smgw)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jannickfahlbusch&repository=ha-ppc-smgw&category=integration)
 
 HomeAssistant component to read SMGWs.
 


### PR DESCRIPTION
Updated HACS repository link to include category parameter, because it won't work if you haven't added the repo to HACS before and just show this:

<img width="393" height="48" alt="image" src="https://github.com/user-attachments/assets/faa2a3eb-c793-40c2-85d5-51e158d9ef8b" />

## Summary by Sourcery

Documentation:
- Update the README HACS badge link to include the integration category in the repository redirect URL.