### PR TITLE
Chore: add EMH Casa to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ HomeAssistant component to read SMGWs.
 This custom integration allows you to integrate the following Smart Meter Gateways into HomeAssistant:
 * PPC SMGW
 * Theben Conexa
+* EMH Casa
 
 ## Installation
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add EMH Casa to the list of supported Smart Meter Gateways in the README.