### PR TITLE
Activate all HACS validation checks

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,7 +3,7 @@ name: "Validate"
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "0 0 * * *"
+    - cron: "0 0 * * *"
   push:
     branches:
       - "main"
@@ -16,22 +16,20 @@ jobs:
     name: "Hassfest Validation"
     runs-on: "ubuntu-latest"
     steps:
-        - name: "Checkout the repository"
-          uses: "actions/checkout@v6.0.2"
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
 
-        - name: "Run hassfest validation"
-          uses: "home-assistant/actions/hassfest@master"
+      - name: "Run hassfest validation"
+        uses: "home-assistant/actions/hassfest@master"
 
   hacs:
     name: "HACS Validation"
     runs-on: "ubuntu-latest"
     steps:
-        - name: "Checkout the repository"
-          uses: "actions/checkout@v6.0.2"
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
 
-        - name: "Run HACS validation"
-          uses: "hacs/action@main"
-          with:
-            category: "integration"
-            # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-            ignore: "brands"
+      - name: "Run HACS validation"
+        uses: "hacs/action@main"
+        with:
+          category: "integration"


### PR DESCRIPTION
Since the integration now has brand icons with #113 we can also let the HACS validation validate it

## Summary by Sourcery

Enable full HACS validation for the integration and clean up the validation workflow formatting.

CI:
- Update the GitHub Actions validation workflow to run HACS validation without ignoring brand checks.
- Normalize indentation and cron formatting in the validation workflow configuration.