### PR TITLE
fix: support gateways using Digest auth without session cookie

### DIFF
--- a/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
@@ -29,13 +29,23 @@ class PPCSmgw:
         self.httpx_client = httpx_client
         self.logger = logger
 
-        self._cookies = {}
+        self._cookies: dict | None = None
         self._token = ""
+        self._use_digest_only = False
 
         self.firmware_version = None
 
     def _post_data(self, action):
+        if self._use_digest_only and not self._token:
+            return f"action={action}"
         return f"tkn={self._token}&action={action}"
+
+    def _request_kwargs(self, timeout: int = 10) -> dict:
+        """Build common kwargs for authenticated requests."""
+        kwargs = {"timeout": timeout, "auth": self._auth}
+        if self._cookies is not None:
+            kwargs["cookies"] = self._cookies
+        return kwargs
 
     async def _login(self):
         self.logger.info("Attempting to login to PPC SMGW")
@@ -46,8 +56,9 @@ class PPCSmgw:
         self._auth = httpx.DigestAuth(username=self.username, password=self.password)
 
         # Clear session state upfront so no stale credentials survive any failure path
-        self._cookies = {}
+        self._cookies = None
         self._token = ""
+        self._use_digest_only = False
 
         # TODO: Find a way to remove the cookie here!
         # See https://github.com/encode/httpx/pull/3065
@@ -72,17 +83,38 @@ class PPCSmgw:
             self.logger.error(msg)
             raise ConnectionError(msg) from e
 
-        if "session" not in response.cookies:
-            msg = f"Login to {self.host} failed: no session cookie in response (HTTP {response.status_code})"
+        # Some gateways (e.g. SMGW-K-2B-111-10) use pure Digest auth without
+        # issuing a session cookie. If we got HTTP 200, auth succeeded regardless.
+        if response.status_code != 200:
+            msg = f"Login to {self.host} failed: HTTP {response.status_code}"
             self.logger.error(msg)
             raise ConnectionError(msg)
-        self._cookies = {"Cookie": response.cookies["session"]}
+
+        if "session" in response.cookies:
+            self._cookies = {"Cookie": response.cookies["session"]}
+            self._use_digest_only = False
+        else:
+            # Stateless Digest auth — no cookie, rely on self._auth for requests
+            self.logger.info(
+                "No session cookie returned (HTTP 200); using stateless Digest auth"
+            )
+            self._cookies = None
+            self._use_digest_only = True
 
         soup = await asyncio.to_thread(BeautifulSoup, response.content, "html.parser")
         tags = soup.find_all("input")
-        self._token = tags[0].get("value")
+        if not tags:
+            if not self._use_digest_only:
+                # Cookie-based gateways must provide a CSRF token
+                msg = f"Login to {self.host} failed: no CSRF token found in response"
+                self.logger.error(msg)
+                raise ConnectionError(msg)
+            # Stateless Digest gateways may not use CSRF tokens
+            self._token = ""
+        else:
+            self._token = tags[0].get("value")
 
-        self.logger.info("Got cookie response, assuming we are logged in")
+        self.logger.info("Login successful")
 
         return response
 
@@ -98,9 +130,7 @@ class PPCSmgw:
             response = await self.httpx_client.post(
                 self.host,
                 data=self._post_data("meterform"),
-                cookies=self._cookies,
-                timeout=10,
-                auth=self._auth,
+                **self._request_kwargs(),
             )
         except Exception as e:
             self.logger.error(f"Error getting meter readings: {e}")
@@ -113,6 +143,16 @@ class PPCSmgw:
         self._set_firwmware_version(soup)
 
         sel = soup.find(id="meterform_select_meter")
+        if sel is None:
+            self.logger.error(
+                "Meter form not found in response — the gateway may have rejected the request. "
+                f"Response length: {len(response.content)} bytes"
+            )
+            self.logger.debug(f"Response content: {response.content}")
+            await self._logout()
+            raise ConnectionError(
+                f"Unexpected response from {self.host}: meter form not found"
+            )
         meter_val = sel.findChild()
         meter_id = meter_val.attrs.get("value")
         post_data = self._post_data("showMeterProfile") + f"&mid={meter_id}"
@@ -121,9 +161,7 @@ class PPCSmgw:
             response = await self.httpx_client.post(
                 self.host,
                 data=post_data,
-                cookies=self._cookies,
-                timeout=10,
-                auth=self._auth,
+                **self._request_kwargs(),
             )
         except Exception as e:
             self.logger.error(f"Error getting meter profile: {e}")
@@ -195,14 +233,12 @@ class PPCSmgw:
             response = await self.httpx_client.post(
                 self.host,
                 data=self._post_data("logout"),
-                cookies=self._cookies,
-                timeout=10,
-                auth=self._auth,
+                **self._request_kwargs(),
             )
             self.logger.debug(f"Got response: {response}\nContent: {response.content}")
 
         except Exception as e:
-            self._cookies = {}
+            self._cookies = None
             self._token = ""
 
             self.logger.error(f"Error logging out: {e}")
@@ -219,9 +255,7 @@ class PPCSmgw:
         response = await self.httpx_client.post(
             self.host,
             data=self._post_data("selftest"),
-            cookies=self._cookies,
-            timeout=10,
-            auth=self._auth,
+            **self._request_kwargs(),
         )
 
         self.logger.debug(f"Got response: {response}\nContent: {response.content}")


### PR DESCRIPTION
Some SMGW models (e.g. SMGW-K-2B-111-10) authenticate via HTTP Digest but do not return a session cookie. Previously this caused a ConnectionError even though authentication succeeded (HTTP 200).

Now, if the response is 200 OK but contains no session cookie, the integration falls back to stateless Digest auth for subsequent requests. Cookie-based gateways continue to work as before.

Fixes #136

## Summary by Sourcery

Bug Fixes:
- Fix ConnectionError on Digest-auth gateways that return HTTP 200 but no session cookie by supporting stateless Digest authentication.