### PR TITLE
Add experimental switch to use dedicated Python library for PPC 

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -7,3 +7,4 @@ logger:
   default: info
   logs:
     custom_components.ppc_smgw: debug
+    py_ppc_smgw: debug

--- a/custom_components/ppc_smgw/__init__.py
+++ b/custom_components/ppc_smgw/__init__.py
@@ -15,7 +15,13 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.loader import async_get_loaded_integration
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, CONF_METER_TYPE
+from .const import (
+    CONF_METER_TYPE,
+    CONF_USE_LIBRARY,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_USE_LIBRARY,
+    DOMAIN,
+)
 from .gateways.emh.const import CONF_METER_ID as EMH_CONF_METER_ID
 from .coordinator import SMGwDataUpdateCoordinator, ConfigEntry, Data
 from custom_components.ppc_smgw.gateways.gateway import Gateway
@@ -61,6 +67,9 @@ async def async_setup_entry(
     match Vendor(entry.data[CONF_METER_TYPE]):
         case Vendor.PPC:
             _LOGGER.debug(f"Initializing PPC SMGW client")
+            # entry.data is the single source of truth (options are merged into
+            # data by the options flow), matching how CONF_DEBUG is read above.
+            use_library = entry.data.get(CONF_USE_LIBRARY, DEFAULT_USE_LIBRARY)
             client = PPC_SMGW(
                 host=entry.data[CONF_HOST],
                 username=entry.data[CONF_USERNAME],
@@ -68,6 +77,7 @@ async def async_setup_entry(
                 websession=create_async_httpx_client(hass, verify_ssl=False),
                 logger=_LOGGER,
                 debug=development_mode,
+                use_library=use_library,
             )
         case Vendor.Theben:
             _LOGGER.debug(f"Initializing Theben client")

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -24,8 +24,10 @@ from homeassistant.helpers.selector import (
 
 from .const import (
     CONF_METER_TYPE,
+    CONF_USE_LIBRARY,
     DEFAULT_DEBUG,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_USE_LIBRARY,
     DOMAIN,
     REPO_URL,
 )
@@ -52,6 +54,8 @@ def build_username_password_schema(
     default_debug: bool = False,
     optional_password: bool = False,
     default_meter_id: str | None = None,
+    allow_use_library: bool = False,
+    default_use_library: bool = False,
 ) -> vol.Schema:
     """Build a schema for username/password configuration.
 
@@ -64,6 +68,8 @@ def build_username_password_schema(
         default_debug: Default value for the debug field (if allowed).
         optional_password: If True, password can be left blank (for options flow).
         default_meter_id: If not None, include an optional meter_id field (EMH only).
+        allow_use_library: Whether to include the library toggle (PPC options only).
+        default_use_library: Default value for the library toggle (if allowed).
 
     Returns:
         A voluptuous Schema for the configuration form.
@@ -88,6 +94,9 @@ def build_username_password_schema(
 
     if allow_debugging:
         schema[vol.Optional(CONF_DEBUG, default=default_debug)] = bool
+
+    if allow_use_library:
+        schema[vol.Optional(CONF_USE_LIBRARY, default=default_use_library)] = bool
 
     if default_meter_id is not None:
         schema[vol.Optional(emh_const.CONF_METER_ID, default=default_meter_id)] = str
@@ -378,8 +387,13 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
         Returns:
             A voluptuous Schema populated with current configuration values.
         """
-        # Determine vendor type and appropriate defaults
-        vendor = self.data.get(CONF_METER_TYPE)
+        # Determine vendor type and appropriate defaults. meter_type is stored
+        # as a plain string in entry.data, so coerce it to the Vendor enum before
+        # comparing (a bare string never equals a Vendor member).
+        try:
+            vendor = Vendor(self.data.get(CONF_METER_TYPE))
+        except ValueError:
+            vendor = Vendor.PPC
 
         # Get vendor-specific default name
         if vendor == Vendor.Theben:
@@ -409,9 +423,14 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
         # Determine if this is a PPC device (only vendor with debug option)
         is_ppc = vendor == Vendor.PPC
         current_debug = DEFAULT_DEBUG
+        current_use_library = DEFAULT_USE_LIBRARY
         if is_ppc:
             current_debug = self.options.get(
                 CONF_DEBUG, self.data.get(CONF_DEBUG, DEFAULT_DEBUG)
+            )
+            current_use_library = self.options.get(
+                CONF_USE_LIBRARY,
+                self.data.get(CONF_USE_LIBRARY, DEFAULT_USE_LIBRARY),
             )
 
         # For EMH, include the meter_id field
@@ -431,6 +450,8 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
             default_debug=current_debug,
             optional_password=True,
             default_meter_id=current_meter_id,
+            allow_use_library=is_ppc,
+            default_use_library=current_use_library,
         )
 
     def _update_options(self):

--- a/custom_components/ppc_smgw/const.py
+++ b/custom_components/ppc_smgw/const.py
@@ -17,6 +17,12 @@ REPO_URL = "https://github.com/jannickfahlbusch/ha-ppc-smgw"
 
 CONF_METER_TYPE = "meter_type"
 
+# Opt-in toggle (PPC options flow only) to route data fetching through the
+# standalone py-ppc-smgw library instead of the built-in client. Default keeps
+# the built-in client so existing installations are unaffected.
+CONF_USE_LIBRARY = "use_library"
+DEFAULT_USE_LIBRARY = False
+
 SENSOR_TYPES = [
     SensorEntityDescription(
         key="1-0:1.8.0",

--- a/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
@@ -1,12 +1,25 @@
-import logging
 import asyncio
+import logging
+from datetime import datetime
 
 import httpx
 import urllib3
+from homeassistant.util.dt import now
+from py_ppc_smgw import PPCSMGWClient
+from py_ppc_smgw.types import FirmwareVersion, Meter
 
 from custom_components.ppc_smgw.gateways.gateway import Gateway
+from custom_components.ppc_smgw.gateways.ppc.const import (
+    DEFAULT_MODEL,
+    DEFAULT_NAME,
+    MANUFACTURER,
+)
 from custom_components.ppc_smgw.gateways.ppc.ppcsmgw.ppc_smgw import PPCSmgw
-from custom_components.ppc_smgw.gateways.reading import Information, FakeInformation
+from custom_components.ppc_smgw.gateways.reading import (
+    FakeInformation,
+    Information,
+    Reading,
+)
 
 # Needed as the PPC SMGW uses a self-signed certificate
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -21,8 +34,13 @@ class PPC_SMGW(Gateway):
         websession: httpx.AsyncClient,
         logger: logging.Logger,
         debug: bool = False,
+        use_library: bool = False,
     ) -> None:
         super().__init__(host, username, password, websession, logger, debug)
+
+        # Opt-in flag: route through the py-ppc-smgw library instead of the
+        # built-in client. Default keeps the built-in client (below) unchanged.
+        self.use_library = use_library
 
         self.ppc_smgw_client = PPCSmgw(
             host=host,
@@ -42,12 +60,89 @@ class PPC_SMGW(Gateway):
             # We should emulate this here to avoid timing issues
             await asyncio.sleep(15)
             self.data = FakeInformation
+        elif self.use_library:
+            self.data = await self._get_data_via_library()
         else:
             self.data = await self.ppc_smgw_client.get_data()
 
         return self.data
 
+    async def _get_data_via_library(self) -> Information:
+        """Fetch data through the py-ppc-smgw library.
+
+        Reads only the first meter to keep parity with the built-in client.
+        The firmware string is reconstructed in the built-in client's
+        "<bootstream>-<services>" format so the device info stays identical.
+        """
+        async with PPCSMGWClient(
+            host=self.host,
+            username=self.username,
+            password=self.password,
+            httpx_client=self.websession,
+            logger=self.logger,
+        ) as client:
+            readings: dict[str, Reading] = {}
+            last_ts: datetime | None = None
+
+            meters: list[Meter] = await client.get_meters()
+            if meters:
+                meter_readings = await client.get_meter_reading(meters[0])
+                for obis, reading in meter_readings.items():
+                    ts = self._as_aware(reading.timestamp)
+                    readings[obis] = Reading(
+                        value=reading.value, timestamp=ts, obis=obis
+                    )
+                    if ts is not None and (last_ts is None or ts > last_ts):
+                        last_ts = ts
+
+            firmware = self._construct_firmware_version(
+                await client.get_firmware_versions()
+            )
+
+        return Information(
+            name=DEFAULT_NAME,
+            model=DEFAULT_MODEL,
+            manufacturer=MANUFACTURER,
+            firmware_version=firmware,
+            last_update=last_ts or now(),
+            readings=readings,
+        )
+
+    @staticmethod
+    def _as_aware(dt: datetime | None) -> datetime | None:
+        """Make a datetime tz-aware, mirroring the built-in client's behaviour.
+
+        The last_update sensor is a TIMESTAMP device class, so naive values
+        would be rejected by Home Assistant.
+        """
+        if dt is None:
+            return None
+        return dt.replace(tzinfo=now().tzinfo) if dt.tzinfo is None else dt
+
+    @staticmethod
+    def _construct_firmware_version(firmware_versions: list[FirmwareVersion]) -> str:
+        """Rebuild the built-in client's firmware string.
+
+        Format is "<smgw-bootstream>-<smgw-services>"; missing components
+        collapse to an empty segment.
+        """
+        by_component = {fw.component: fw.version for fw in firmware_versions}
+        bootstream = by_component.get("smgw-bootstream", "")
+        services = by_component.get("smgw-services", "")
+        return f"{bootstream}-{services}"
+
     async def reboot(self):
         """Reboot the gateway."""
         self.logger.info("Rebooting Gateway")
+
+        if self.use_library:
+            async with PPCSMGWClient(
+                host=self.host,
+                username=self.username,
+                password=self.password,
+                httpx_client=self.websession,
+                logger=self.logger,
+            ) as client:
+                return await client.reboot()
+
         return await self.ppc_smgw_client.reboot()

--- a/custom_components/ppc_smgw/manifest.json
+++ b/custom_components/ppc_smgw/manifest.json
@@ -10,7 +10,8 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jannickfahlbusch/ha-ppc-smgw/issues",
   "requirements": [
-    "beautifulsoup4"
+    "beautifulsoup4>=4.13.3",
+    "py-ppc-smgw==0.1.2"
   ],
   "version": "0.0.21"
 }

--- a/custom_components/ppc_smgw/strings.json
+++ b/custom_components/ppc_smgw/strings.json
@@ -31,10 +31,12 @@
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "debug": "Development mode - DO NOT USE (Uses fake data)",
+          "use_library": "Use py-ppc-smgw client library (experimental)",
           "meter_id": "Meter ID (EMH only — leave blank for auto-detect)"
         },
         "data_description": {
-          "password": "Leave blank to keep the current password"
+          "password": "Leave blank to keep the current password",
+          "use_library": "Leave off to keep the built-in client (default)."
         }
       }
     }

--- a/custom_components/ppc_smgw/translations/en.json
+++ b/custom_components/ppc_smgw/translations/en.json
@@ -40,10 +40,12 @@
             "password": "Password",
             "scan_interval": "Polling Interval in minutes",
             "debug": "Development mode - DO NOT USE (Uses fake data)",
+            "use_library": "Use py-ppc-smgw client library (experimental)",
             "meter_id": "Meter ID (EMH only — leave blank for auto-detect)"
           },
           "data_description": {
-            "password": "Leave blank to keep the current password"
+            "password": "Leave blank to keep the current password",
+            "use_library": "Leave off to keep the built-in client (default)."
           }
         }
       }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
-    "name": "PPC SMGW",
-    "content_in_root": false,
-    "render_readme": true
-  }
+  "name": "PPC SMGW",
+  "homeassistant": "2026.3.0",
+  "content_in_root": false,
+  "render_readme": true
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "homeassistant": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Group py-ppc-smgw bumps across manifest.json and requirements.txt into one PR",
+      "matchPackageNames": ["py-ppc-smgw"],
+      "groupName": "py-ppc-smgw"
+    }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-homeassistant>=2026.4.4
+homeassistant>=2026.3.0
 
 ruff>=0.15.14
 beautifulsoup4>=4.14.3
+py-ppc-smgw==0.1.2

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -427,3 +427,24 @@ class TestOptionsFlow:
 
         assert "use_library" in keys
         assert "debug" in keys
+
+    async def test_options_schema_falls_back_to_ppc_for_unknown_meter_type(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """An unrecognised meter_type must not blow up the options flow.
+
+        Old or corrupted entries may hold a value that is not a Vendor member;
+        the coercion falls back to PPC so the form still renders (with the
+        PPC-specific toggles) instead of raising ValueError.
+        """
+        data = {**ppc_config_data, CONF_METER_TYPE: "UNKNOWN"}
+        entry = create_mock_config_entry(data=data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        schema = options_flow._build_options_schema()
+        keys = {getattr(k, "schema", k) for k in schema.schema}
+
+        assert "use_library" in keys
+        assert "debug" in keys

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -368,3 +368,62 @@ class TestOptionsFlow:
 
         assert result["type"] == FlowResultType.FORM
         assert result["errors"] == {CONF_HOST: "already_configured"}
+
+    async def test_options_flow_enables_use_library(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """Toggling use_library on persists it to entry.data."""
+        entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        result = await options_flow.async_step_user(
+            user_input={
+                k: ppc_config_data[k] for k in ["name", "host", "username", "password"]
+            }
+            | {"scan_interval": 5, "debug": False, "use_library": True}
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data["use_library"] is True
+
+    async def test_options_flow_use_library_defaults_false_when_absent(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """Omitting use_library leaves the built-in client (default) active."""
+        entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        result = await options_flow.async_step_user(
+            user_input={
+                k: ppc_config_data[k] for k in ["name", "host", "username", "password"]
+            }
+            | {"scan_interval": 5, "debug": False}
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data.get("use_library", False) is False
+
+    async def test_options_schema_shows_ppc_toggles_for_string_meter_type(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """meter_type is stored as a string; the PPC toggles must still appear.
+
+        Regression: entry.data["meter_type"] is the raw string "PPC", not the
+        Vendor enum, so the options schema must coerce it before deciding
+        is_ppc — otherwise both the debug and use_library toggles vanish.
+        """
+        data = {**ppc_config_data, CONF_METER_TYPE: "PPC"}
+        entry = create_mock_config_entry(data=data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        schema = options_flow._build_options_schema()
+        keys = {getattr(k, "schema", k) for k in schema.schema}
+
+        assert "use_library" in keys
+        assert "debug" in keys

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -110,6 +110,67 @@ class TestInit:
             # Verify the error message contains the host
             assert ppc_config_data["host"] in str(exc_info.value)
 
+    async def test_setup_entry_passes_use_library_when_enabled(
+        self, hass: HomeAssistant, ppc_config_data, mock_gateway
+    ):
+        """use_library from entry.data must be forwarded to PPC_SMGW."""
+        from custom_components.ppc_smgw.const import CONF_USE_LIBRARY
+
+        config_data = {**ppc_config_data, CONF_USE_LIBRARY: True}
+        entry = create_mock_config_entry(data=config_data)
+
+        mock_integration = MagicMock()
+        mock_integration.domain = DOMAIN
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        ppc_cls = MagicMock(return_value=mock_gateway)
+
+        with (
+            patch("custom_components.ppc_smgw.PPC_SMGW", ppc_cls),
+            patch("custom_components.ppc_smgw.create_async_httpx_client"),
+            patch(
+                "custom_components.ppc_smgw.async_get_loaded_integration",
+                return_value=mock_integration,
+            ),
+            patch.object(hass.config_entries, "async_forward_entry_setups"),
+            patch(
+                "custom_components.ppc_smgw.SMGwDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        assert ppc_cls.call_args.kwargs["use_library"] is True
+
+    async def test_setup_entry_defaults_use_library_false(
+        self, hass: HomeAssistant, ppc_config_data, mock_gateway
+    ):
+        """Without the key in entry.data, PPC_SMGW must get use_library=False."""
+        entry = create_mock_config_entry(data=ppc_config_data)
+
+        mock_integration = MagicMock()
+        mock_integration.domain = DOMAIN
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        ppc_cls = MagicMock(return_value=mock_gateway)
+
+        with (
+            patch("custom_components.ppc_smgw.PPC_SMGW", ppc_cls),
+            patch("custom_components.ppc_smgw.create_async_httpx_client"),
+            patch(
+                "custom_components.ppc_smgw.async_get_loaded_integration",
+                return_value=mock_integration,
+            ),
+            patch.object(hass.config_entries, "async_forward_entry_setups"),
+            patch(
+                "custom_components.ppc_smgw.SMGwDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        assert ppc_cls.call_args.kwargs["use_library"] is False
+
     async def test_setup_entry_uses_configured_scan_interval(
         self, hass: HomeAssistant, mock_gateway
     ):

--- a/tests/test_ppc_adapter.py
+++ b/tests/test_ppc_adapter.py
@@ -1,0 +1,146 @@
+"""Tests for the PPC adapter's built-in vs library data paths."""
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.ppc_smgw.gateways.ppc.ppc_smgw import PPC_SMGW
+from custom_components.ppc_smgw.gateways.ppc.const import (
+    DEFAULT_MODEL,
+    MANUFACTURER,
+)
+from custom_components.ppc_smgw.gateways.reading import Information, Reading
+
+from py_ppc_smgw.types import FirmwareVersion, Meter, Reading as LibReading
+
+_ADAPTER = "custom_components.ppc_smgw.gateways.ppc.ppc_smgw"
+
+
+def _make_adapter(use_library: bool) -> PPC_SMGW:
+    """Build a real PPC_SMGW adapter with a stub websession/logger."""
+    return PPC_SMGW(
+        host="https://192.168.1.200/cgi-bin/hanservice.cgi",
+        username="testuser",
+        password="testpass",
+        websession=MagicMock(),
+        logger=logging.getLogger("test.ppc_adapter"),
+        use_library=use_library,
+    )
+
+
+def _library_client_mock(meters=None, readings=None, firmware=None) -> MagicMock:
+    """Return a MagicMock that behaves as the PPCSMGWClient async context manager."""
+    client = MagicMock()
+    client.get_meters = AsyncMock(return_value=meters or [])
+    client.get_meter_reading = AsyncMock(return_value=readings or {})
+    client.get_firmware_versions = AsyncMock(return_value=firmware or [])
+    client.reboot = AsyncMock()
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=cm)
+    factory.client = client  # convenience handle for assertions
+    return factory
+
+
+@pytest.mark.asyncio
+class TestPPCAdapterDataPath:
+    """get_data() must pick the right client based on use_library."""
+
+    async def test_builtin_path_returns_client_data_untouched(self):
+        """use_library=False delegates to the built-in client, unchanged."""
+        adapter = _make_adapter(use_library=False)
+        canned = Information(
+            name="N",
+            model="M",
+            manufacturer="Mfr",
+            firmware_version="1-2",
+            last_update=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            readings={},
+        )
+        adapter.ppc_smgw_client.get_data = AsyncMock(return_value=canned)
+
+        with patch(f"{_ADAPTER}.PPCSMGWClient") as lib_cls:
+            result = await adapter.get_data()
+
+        assert result is canned
+        lib_cls.assert_not_called()
+
+    async def test_library_path_maps_readings_and_firmware(self):
+        """use_library=True reads first meter, maps readings, joins firmware."""
+        adapter = _make_adapter(use_library=True)
+
+        naive = datetime(2024, 12, 20, 16, 0, 1)  # tz-naive on purpose
+        older = datetime(2024, 12, 20, 15, 0, 0)
+        readings = {
+            "1-0:1.8.0": LibReading(
+                value="724.9204", timestamp=naive, obis="1-0:1.8.0"
+            ),
+            "1-0:2.8.0": LibReading(value="3.0557", timestamp=older, obis="1-0:2.8.0"),
+        }
+        firmware = [
+            FirmwareVersion(component="smgw-bootstream", version="33918", checksum="x"),
+            FirmwareVersion(component="smgw-services", version="34868", checksum="y"),
+        ]
+        factory = _library_client_mock(
+            meters=[Meter(mid="mid", name="n")],
+            readings=readings,
+            firmware=firmware,
+        )
+
+        with patch(f"{_ADAPTER}.PPCSMGWClient", factory):
+            result = await adapter.get_data()
+
+        assert isinstance(result, Information)
+        assert result.model == DEFAULT_MODEL
+        assert result.manufacturer == MANUFACTURER
+        assert result.firmware_version == "33918-34868"
+        # Readings mapped to the integration's own Reading type, tz-aware.
+        assert isinstance(result.readings["1-0:1.8.0"], Reading)
+        assert result.readings["1-0:1.8.0"].timestamp.tzinfo is not None
+        # last_update is the newest reading timestamp.
+        assert result.last_update == adapter._as_aware(naive)
+        # Only the first meter is read (parity with built-in client).
+        factory.client.get_meter_reading.assert_awaited_once()
+
+    async def test_library_path_no_meters_gives_empty_readings(self):
+        """No meters → empty readings and a tz-aware now() fallback."""
+        adapter = _make_adapter(use_library=True)
+        factory = _library_client_mock(meters=[], firmware=[])
+
+        with patch(f"{_ADAPTER}.PPCSMGWClient", factory):
+            result = await adapter.get_data()
+
+        assert result.readings == {}
+        assert result.last_update.tzinfo is not None
+        assert result.firmware_version == "-"
+        factory.client.get_meter_reading.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestPPCAdapterReboot:
+    """reboot() must target the right client based on use_library."""
+
+    async def test_builtin_reboot_delegates_to_builtin_client(self):
+        adapter = _make_adapter(use_library=False)
+        adapter.ppc_smgw_client.reboot = AsyncMock()
+
+        with patch(f"{_ADAPTER}.PPCSMGWClient") as lib_cls:
+            await adapter.reboot()
+
+        adapter.ppc_smgw_client.reboot.assert_awaited_once()
+        lib_cls.assert_not_called()
+
+    async def test_library_reboot_delegates_to_library_client(self):
+        adapter = _make_adapter(use_library=True)
+        adapter.ppc_smgw_client.reboot = AsyncMock()
+        factory = _library_client_mock()
+
+        with patch(f"{_ADAPTER}.PPCSMGWClient", factory):
+            await adapter.reboot()
+
+        factory.client.reboot.assert_awaited_once()
+        adapter.ppc_smgw_client.reboot.assert_not_awaited()

--- a/tests/test_ppc_adapter.py
+++ b/tests/test_ppc_adapter.py
@@ -120,6 +120,52 @@ class TestPPCAdapterDataPath:
         factory.client.get_meter_reading.assert_not_awaited()
 
 
+def _fw(*components) -> list[FirmwareVersion]:
+    """Build a FirmwareVersion list from (component, version) pairs."""
+    return [
+        FirmwareVersion(component=c, version=v, checksum="x") for c, v in components
+    ]
+
+
+class TestConstructFirmwareVersion:
+    """_construct_firmware_version joins two known components, tolerating gaps.
+
+    The firmware string is cosmetic (PPC exposes no changelog), so a missing
+    component must degrade the string rather than raise and break the poll.
+    """
+
+    @pytest.mark.parametrize(
+        ("firmware", "expected"),
+        [
+            (
+                _fw(("smgw-bootstream", "33918"), ("smgw-services", "34868")),
+                "33918-34868",
+            ),
+            (_fw(("smgw-bootstream", "33918")), "33918-"),  # services missing
+            (_fw(("smgw-services", "34868")), "-34868"),  # bootstream missing
+            (_fw(), "-"),  # nothing reported
+            (_fw(("smgw-other", "1")), "-"),  # only unrelated components
+        ],
+    )
+    def test_joins_and_tolerates_missing_components(self, firmware, expected):
+        assert PPC_SMGW._construct_firmware_version(firmware) == expected
+
+
+class TestAsAware:
+    """_as_aware only touches naive datetimes; None and aware pass through."""
+
+    def test_none_passes_through(self):
+        assert PPC_SMGW._as_aware(None) is None
+
+    def test_aware_datetime_is_returned_unchanged(self):
+        aware = datetime(2024, 12, 20, 16, 0, 1, tzinfo=timezone.utc)
+        assert PPC_SMGW._as_aware(aware) is aware
+
+    def test_naive_datetime_becomes_aware(self):
+        result = PPC_SMGW._as_aware(datetime(2024, 12, 20, 16, 0, 1))
+        assert result.tzinfo is not None
+
+
 @pytest.mark.asyncio
 class TestPPCAdapterReboot:
     """reboot() must target the right client based on use_library."""


### PR DESCRIPTION
## Summary by Sourcery

Add an optional path for PPC gateways to use the external py-ppc-smgw library for data and control while preserving existing behaviour by default.

New Features:
- Introduce a use_library configuration toggle for PPC meters that switches data fetching and reboot operations to the py-ppc-smgw library while leaving the built-in client as the default.
- Expose the use_library option in the PPC options flow and persist it into the config entry data so it is respected on setup.

Enhancements:
- Normalize PPC firmware and reading data returned by the library to match the existing integration data model and device info format.
- Coerce stored meter_type strings back to the Vendor enum in the options flow to ensure PPC-specific toggles (debug and use_library) are always shown.

Build:
- Add py-ppc-smgw as a dependency and relax the minimum Home Assistant version requirement.
- Update development configuration to log py_ppc_smgw at debug level for troubleshooting.

Tests:
- Add tests covering async_setup_entry propagation and defaulting of the use_library flag for PPC entries.
- Add options flow tests to verify use_library persistence, defaulting, and visibility of PPC-specific toggles when meter_type is stored as a string.
- Add adapter tests ensuring get_data() and reboot() route correctly between the built-in client and the library based on use_library.