### PR TITLE
Provide the user with some more information in case of "no session cookie".

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ In order to connect to your Gateway, you need at least the following information
 
 Please note that most providers have configured the SMGW to update the values only every 15 to 20 minutes.
 You should choose an interval that is reasonably large as polling too frequently might lead to a lockdown of the SMGW after a yet to be clarified amount of polls.
+
+## Troubleshooting
+
+* Setup fails with "no session cookie in response (HTTP 200)" - if your SMGW was installed by 'Energy Metering Germany GmbH' for Octopus Energy please contact them. They have to reconfigure the SMGW.

--- a/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
@@ -73,7 +73,11 @@ class PPCSmgw:
             raise ConnectionError(msg) from e
 
         if "session" not in response.cookies:
-            msg = f"Login to {self.host} failed: no session cookie in response (HTTP {response.status_code})"
+            msg = (
+                f"Login to {self.host} failed: no session cookie in response (HTTP {response.status_code}). "
+                f"Please have a look at the section 'Troubleshooting' in"
+                f"https://github.com/jannickfahlbusch/ha-ppc-smgw"
+            )
             self.logger.error(msg)
             raise ConnectionError(msg)
         self._cookies = {"Cookie": response.cookies["session"]}

--- a/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
@@ -75,7 +75,7 @@ class PPCSmgw:
         if "session" not in response.cookies:
             msg = (
                 f"Login to {self.host} failed: no session cookie in response (HTTP {response.status_code}). "
-                f"Please have a look at the section 'Troubleshooting' in"
+                f"Please have a look at the section 'Troubleshooting' in "
                 f"https://github.com/jannickfahlbusch/ha-ppc-smgw"
             )
             self.logger.error(msg)


### PR DESCRIPTION
Provide the user with some more information in case of "no session cookie" from issue #136 

## Summary by Sourcery

Clarify login failure messaging when no session cookie is returned and add troubleshooting guidance for affected smart meter gateway installations.

Enhancements:
- Improve the login error message for missing session cookie by directing users to troubleshooting documentation.

Documentation:
- Add a troubleshooting section to the README describing how to handle the "no session cookie in response" setup failure for specific SMGW providers.