### PR TITLE
Expose Firmware Version as diagnostic sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
+# uv
+uv.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 

--- a/custom_components/ppc_smgw/const.py
+++ b/custom_components/ppc_smgw/const.py
@@ -4,7 +4,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfEnergy
+from homeassistant.const import EntityCategory, UnitOfEnergy
 
 DOMAIN = "ppc_smgw"
 DEFAULT_NAME = "SMGW"
@@ -51,6 +51,14 @@ LastUpdatedSensorDescription = SensorEntityDescription(
     icon="mdi:clock-time-eight",
     native_unit_of_measurement=None,
     device_class=SensorDeviceClass.TIMESTAMP,
+)
+
+FirmwareVersionSensorDescription = SensorEntityDescription(
+    key="firmware_version",
+    name="Firmware Version",
+    icon="mdi:chip",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    entity_registry_enabled_default=True,
 )
 
 RestartGatewayButtonDescription = ButtonEntityDescription(

--- a/custom_components/ppc_smgw/sensor.py
+++ b/custom_components/ppc_smgw/sensor.py
@@ -5,10 +5,15 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import SENSOR_TYPES, LastUpdatedSensorDescription
-from .coordinator import SMGwDataUpdateCoordinator, ConfigEntry
-from .entity import SMGWEntity
 from custom_components.ppc_smgw.gateways.reading import Information
+
+from .const import (
+    SENSOR_TYPES,
+    FirmwareVersionSensorDescription,
+    LastUpdatedSensorDescription,
+)
+from .coordinator import ConfigEntry, SMGwDataUpdateCoordinator
+from .entity import SMGWEntity
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
@@ -33,6 +38,13 @@ async def async_setup_entry(
         LastUpdatedSensor(
             coordinator=entry.runtime_data.coordinator,
             entity_description=LastUpdatedSensorDescription,
+        )
+    )
+
+    entities.append(
+        FirmwareSensor(
+            coordinator=entry.runtime_data.coordinator,
+            entity_description=FirmwareVersionSensorDescription,
         )
     )
 
@@ -94,3 +106,33 @@ class LastUpdatedSensor(SMGWEntity, SensorEntity):
             return None
 
         return data.last_update
+
+
+class FirmwareSensor(SMGWEntity, SensorEntity):
+    """Sensor for the gateway firmware version."""
+
+    def __init__(
+        self,
+        coordinator: SMGwDataUpdateCoordinator,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor class."""
+        super().__init__(coordinator, entity_description)
+        self.entity_description = entity_description
+
+        self._attr_unique_id = f"sensor.{self.get_entity_id_template()}"
+        self.entity_id = self._attr_unique_id
+        self._cached_firmware_version: str | None = None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the firmware version."""
+        data = self.coordinator.data
+
+        if not isinstance(data, Information):
+            return self._cached_firmware_version
+
+        if data.firmware_version and data.firmware_version != "Unknown":
+            self._cached_firmware_version = data.firmware_version
+
+        return self._cached_firmware_version

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,19 +1,22 @@
 """Tests for the PPC SMGW sensor platform."""
 
 import pytest
+from dataclasses import replace
 from datetime import datetime
 from unittest.mock import MagicMock
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.core import HomeAssistant
 
 from custom_components.ppc_smgw.sensor import (
-    OBISSensor,
+    FirmwareSensor,
     LastUpdatedSensor,
+    OBISSensor,
     async_setup_entry,
 )
 from custom_components.ppc_smgw.const import (
-    SENSOR_TYPES,
+    FirmwareVersionSensorDescription,
     LastUpdatedSensorDescription,
+    SENSOR_TYPES,
 )
 from custom_components.ppc_smgw.gateways.reading import Information, Reading
 from custom_components.ppc_smgw.coordinator import Data
@@ -73,8 +76,8 @@ class TestSensorPlatformSetup:
 
         await async_setup_entry(hass, entry, mock_add_entities)
 
-        # Should create len(SENSOR_TYPES) + 1 (LastUpdatedSensor)
-        expected_count = len(SENSOR_TYPES) + 1
+        # Should create len(SENSOR_TYPES) + 1 (LastUpdatedSensor) + 1 (FirmwareSensor)
+        expected_count = len(SENSOR_TYPES) + 2
         mock_add_entities.assert_called_once()
 
         # Get the entities list that was passed
@@ -86,9 +89,11 @@ class TestSensorPlatformSetup:
         last_update_sensors = [
             e for e in entities_list if isinstance(e, LastUpdatedSensor)
         ]
+        firmware_sensors = [e for e in entities_list if isinstance(e, FirmwareSensor)]
 
         assert len(obis_sensors) == len(SENSOR_TYPES)
         assert len(last_update_sensors) == 1
+        assert len(firmware_sensors) == 1
 
     async def test_async_setup_entry_uses_coordinator(
         self, hass: HomeAssistant, ppc_config_data
@@ -193,3 +198,39 @@ class TestLastUpdatedSensor:
         )
 
         assert sensor.native_value == valid_information.last_update
+
+
+class TestFirmwareSensor:
+    """Test the FirmwareSensor class."""
+
+    @pytest.mark.parametrize(
+        ("poll_sequence", "expected"),
+        [
+            # (firmware value per poll; None means data is not an Information object)
+            pytest.param([None], None, id="invalid_and_uncached"),
+            pytest.param(["1.0.0"], "1.0.0", id="valid_data"),
+            pytest.param(["1.0.0", "Unknown"], "1.0.0", id="caches_across_unknown"),
+            pytest.param(["Unknown"], None, id="only_unknown_received"),
+            pytest.param(["1.0.0", None], "1.0.0", id="caches_across_invalid"),
+        ],
+    )
+    def test_native_value(
+        self, mock_coordinator, valid_information, poll_sequence, expected
+    ):
+
+        sensor = FirmwareSensor(
+            coordinator=mock_coordinator,
+            entity_description=FirmwareVersionSensorDescription,
+        )
+
+        result = None
+        for firmware in poll_sequence:
+            if firmware is None:
+                mock_coordinator.data = None
+            else:
+                mock_coordinator.data = replace(
+                    valid_information, firmware_version=firmware
+                )
+            result = sensor.native_value
+
+        assert result == expected


### PR DESCRIPTION
## Summary by Sourcery

Expose the gateway firmware version as a dedicated diagnostic sensor entity and ensure it is created during setup.

New Features:
- Add a FirmwareSensor entity that surfaces the gateway firmware version as a diagnostic sensor.
- Introduce a FirmwareVersionSensorDescription with appropriate metadata for the firmware version sensor.

Enhancements:
- Update sensor setup to register the firmware version sensor alongside existing OBIS and last-updated sensors.
- Cache the last valid firmware version in the sensor to preserve the value across invalid or unknown readings.

Tests:
- Extend sensor tests to cover creation of the firmware sensor on setup and the firmware value caching behaviour under various data scenarios.