### PR TITLE
Enable ruff linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,9 +25,8 @@ jobs:
         - name: "Install requirements"
           run: python3 -m pip install -r requirements.txt
 
-#        ToDo: Reenable this after the integration has proper docstrings and fulfills the standards of ruff/HA
-#        - name: "Lint"
-#          run: python3 -m ruff check .
+        - name: "Lint"
+          run: python3 -m ruff check .
 
         - name: "Format"
           run: python3 -m ruff format . --check --diff

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,12 +8,49 @@ select = [
 ]
 
 ignore = [
-    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
-    "D203", # no-blank-line-before-class (incompatible with formatter)
-    "D212", # multi-line-summary-first-line (incompatible with formatter)
-    "COM812", # incompatible with formatter
-    "ISC001", # incompatible with formatter
+    "A001",
+    "ANN",
+    "ARG",
+    "BLE",
+    "COM812",
+    "CPY",
+    "D",
+    "E501",
+    "EM",
+    "FBT",
+    "FIX",
+    "G004",
+    "INP",
+    "ISC001",
+    "N801",
+    "PERF",
+    "PLR",
+    "RUF012",
+    "S501",
+    "TC",
+    "TD",
+    "TID252",
+    "TRY",
 ]
+
+[lint.per-file-ignores]
+"tests/*" = [
+    "ARG",
+    "DTZ",
+    "S",
+    "SLF001",
+]
+"scripts/*" = [
+    "C408",
+    "INP001",
+    "PTH",
+    "T201",
+]
+
+[lint.isort]
+force-sort-within-sections = true
+known-first-party = ["custom_components.ppc_smgw"]
+combine-as-imports = true
 
 [lint.flake8-pytest-style]
 fixture-parentheses = false

--- a/custom_components/ppc_smgw/__init__.py
+++ b/custom_components/ppc_smgw/__init__.py
@@ -1,19 +1,25 @@
-import logging
 from datetime import timedelta
+import logging
 
-import voluptuous as vol
 from homeassistant.const import (
+    CONF_DEBUG,
     CONF_HOST,
     CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
     Platform,
-    CONF_SCAN_INTERVAL,
-    CONF_DEBUG,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.loader import async_get_loaded_integration
+import voluptuous as vol
+
+from custom_components.ppc_smgw.gateways.emh.emh import EMHGateway
+from custom_components.ppc_smgw.gateways.gateway import Gateway
+from custom_components.ppc_smgw.gateways.ppc.ppc_smgw import PPC_SMGW
+from custom_components.ppc_smgw.gateways.theben.theben import ThebenConexa
+from custom_components.ppc_smgw.gateways.vendors import Vendor
 
 from .const import (
     CONF_METER_TYPE,
@@ -22,13 +28,8 @@ from .const import (
     DEFAULT_USE_LIBRARY,
     DOMAIN,
 )
+from .coordinator import ConfigEntry, Data, SMGwDataUpdateCoordinator
 from .gateways.emh.const import CONF_METER_ID as EMH_CONF_METER_ID
-from .coordinator import SMGwDataUpdateCoordinator, ConfigEntry, Data
-from custom_components.ppc_smgw.gateways.gateway import Gateway
-from custom_components.ppc_smgw.gateways.emh.emh import EMHGateway
-from custom_components.ppc_smgw.gateways.theben.theben import ThebenConexa
-from custom_components.ppc_smgw.gateways.vendors import Vendor
-from custom_components.ppc_smgw.gateways.ppc.ppc_smgw import PPC_SMGW
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
@@ -66,7 +67,7 @@ async def async_setup_entry(
     )
     match Vendor(entry.data[CONF_METER_TYPE]):
         case Vendor.PPC:
-            _LOGGER.debug(f"Initializing PPC SMGW client")
+            _LOGGER.debug("Initializing PPC SMGW client")
             # entry.data is the single source of truth (options are merged into
             # data by the options flow), matching how CONF_DEBUG is read above.
             use_library = entry.data.get(CONF_USE_LIBRARY, DEFAULT_USE_LIBRARY)
@@ -80,7 +81,7 @@ async def async_setup_entry(
                 use_library=use_library,
             )
         case Vendor.Theben:
-            _LOGGER.debug(f"Initializing Theben client")
+            _LOGGER.debug("Initializing Theben client")
             client = ThebenConexa(
                 host=entry.data[CONF_HOST],
                 username=entry.data[CONF_USERNAME],
@@ -90,7 +91,7 @@ async def async_setup_entry(
                 debug=development_mode,
             )
         case Vendor.EMH:
-            _LOGGER.debug(f"Initializing EMH CASA client")
+            _LOGGER.debug("Initializing EMH CASA client")
             client = EMHGateway(
                 host=entry.data[CONF_HOST],
                 username=entry.data[CONF_USERNAME],

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -1,16 +1,15 @@
 import logging
-from typing import Any, Optional
+from typing import Any
 
-import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
+    CONF_DEBUG,
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
-    CONF_DEBUG,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.httpx_client import create_async_httpx_client
@@ -21,6 +20,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+import voluptuous as vol
 
 from .const import (
     CONF_METER_TYPE,
@@ -32,8 +32,9 @@ from .const import (
     REPO_URL,
 )
 from .gateways.emh import const as emh_const
-from .gateways.theben import const as theben_const
+from .gateways.emh.emhcasa.emh_client import EMHCasaClient
 from .gateways.ppc import const as ppc_const
+from .gateways.theben import const as theben_const
 from .gateways.vendors import Vendor
 
 _LOGGER = logging.getLogger(__name__)
@@ -151,7 +152,7 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    data: Optional[dict[str, Any]]
+    data: dict[str, Any] | None
     _errors: dict[str, str] = {}
 
     async def _test_connection(self, host, username, password):
@@ -162,14 +163,11 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        if user_input is not None:
-            if not self._errors:
-                self.data = user_input
-                self.data[CONF_METER_TYPE]: Vendor = Vendor(
-                    user_input.get(CONF_METER_TYPE)
-                )
+        if user_input is not None and not self._errors:
+            self.data = user_input
+            self.data[CONF_METER_TYPE]: Vendor = Vendor(user_input.get(CONF_METER_TYPE))
 
-                return await self.async_step_connection_info(user_input)
+            return await self.async_step_connection_info(user_input)
 
         return self.async_show_form(
             step_id="user",
@@ -265,8 +263,6 @@ class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _discover_emh_meter_ids(self) -> list[str]:
         """Call the EMH gateway and return all available meter IDs."""
-        from .gateways.emh.emhcasa.emh_client import EMHCasaClient
-
         client = EMHCasaClient(
             base_url=self.data[CONF_HOST],
             username=self.data[CONF_USERNAME],

--- a/custom_components/ppc_smgw/coordinator.py
+++ b/custom_components/ppc_smgw/coordinator.py
@@ -1,19 +1,19 @@
-import logging
+from dataclasses import dataclass
 from datetime import timedelta
+import logging
+
+from homeassistant.config_entries import ConfigEntry as HAConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .const import DOMAIN
-from dataclasses import dataclass
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.loader import Integration
 
+from .const import DOMAIN
 from .gateways.gateway import Gateway
 from .gateways.reading import Information
 
-
 _LOGGER = logging.getLogger(__name__)
 
-type ConfigEntry = ConfigEntry[Data]
+type ConfigEntry = HAConfigEntry[Data]
 
 
 class SMGwDataUpdateCoordinator(DataUpdateCoordinator[Information | None]):

--- a/custom_components/ppc_smgw/entity.py
+++ b/custom_components/ppc_smgw/entity.py
@@ -3,11 +3,10 @@ import logging
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from .const import DEFAULT_NAME
 from .coordinator import SMGwDataUpdateCoordinator
-from homeassistant.util import slugify
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ppc_smgw/gateways/emh/emh.py
+++ b/custom_components/ppc_smgw/gateways/emh/emh.py
@@ -1,14 +1,14 @@
-import logging
 import asyncio
+import logging
 
 import httpx
 import urllib3
 
-from custom_components.ppc_smgw import Gateway
-from custom_components.ppc_smgw.gateways.reading import Information, FakeInformation
 from custom_components.ppc_smgw.gateways.emh.emhcasa.emh_client import (
     EMHCasaClient,
 )
+from custom_components.ppc_smgw.gateways.gateway import Gateway
+from custom_components.ppc_smgw.gateways.reading import FakeInformation, Information
 
 # Needed as the SMGW uses a self-signed certificate
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/custom_components/ppc_smgw/gateways/emh/emhcasa/emh_client.py
+++ b/custom_components/ppc_smgw/gateways/emh/emhcasa/emh_client.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import httpx
 
-from ..const import DEFAULT_NAME, DEFAULT_MODEL, MANUFACTURER
 from custom_components.ppc_smgw.gateways.reading import Information, OBISCode, Reading
-from datetime import datetime, timezone
+
+from ..const import DEFAULT_MODEL, DEFAULT_NAME, MANUFACTURER
 
 
 class EMHCasaClient:
@@ -41,7 +43,7 @@ class EMHCasaClient:
             model=DEFAULT_MODEL,
             manufacturer=MANUFACTURER,
             firmware_version="Unknown",
-            last_update=datetime.now(timezone.utc),
+            last_update=datetime.now(UTC),
             readings=await self._get_readings(),
         )
 
@@ -101,7 +103,7 @@ class EMHCasaClient:
             return {}
 
         readings: dict[OBISCode, Reading] = {}
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         for meter_value in meter_reading.get("values", []):
             logical_name = meter_value.get("logical_name", "").split(".")[0]

--- a/custom_components/ppc_smgw/gateways/gateway.py
+++ b/custom_components/ppc_smgw/gateways/gateway.py
@@ -1,7 +1,8 @@
-from custom_components.ppc_smgw.gateways.reading import Information
 import logging
 
 import httpx
+
+from custom_components.ppc_smgw.gateways.reading import Information
 
 
 class Gateway:

--- a/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
@@ -1,12 +1,12 @@
 import asyncio
-import logging
 from datetime import datetime
+import logging
 
-import httpx
-import urllib3
 from homeassistant.util.dt import now
+import httpx
 from py_ppc_smgw import PPCSMGWClient
 from py_ppc_smgw.types import FirmwareVersion, Meter
+import urllib3
 
 from custom_components.ppc_smgw.gateways.gateway import Gateway
 from custom_components.ppc_smgw.gateways.ppc.const import (

--- a/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppcsmgw/ppc_smgw.py
@@ -3,14 +3,14 @@
 import asyncio
 from datetime import datetime
 
-import httpx
 from bs4 import BeautifulSoup
-
-from .errors import SessionCookieStillPresentError
-from ..const import DEFAULT_NAME, DEFAULT_MODEL, MANUFACTURER
-from custom_components.ppc_smgw.gateways.reading import Reading, Information, OBISCode
-
 from homeassistant.util.dt import now
+import httpx
+
+from custom_components.ppc_smgw.gateways.reading import Information, OBISCode, Reading
+
+from ..const import DEFAULT_MODEL, DEFAULT_NAME, MANUFACTURER
+from .errors import SessionCookieStillPresentError
 
 
 class PPCSmgw:

--- a/custom_components/ppc_smgw/gateways/theben/conexa/conexa.py
+++ b/custom_components/ppc_smgw/gateways/theben/conexa/conexa.py
@@ -1,9 +1,11 @@
+from datetime import UTC, datetime
 import logging
+
 import httpx
 
-from ..const import DEFAULT_NAME, DEFAULT_MODEL, MANUFACTURER
 from custom_components.ppc_smgw.gateways.reading import Information, OBISCode, Reading
-from datetime import datetime, timezone
+
+from ..const import DEFAULT_MODEL, DEFAULT_NAME, MANUFACTURER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ class ThebenConexaClient:
             model=DEFAULT_MODEL,
             manufacturer=MANUFACTURER,
             firmware_version=await self._get_firmware_version(),
-            last_update=datetime.now(timezone.utc),
+            last_update=datetime.now(UTC),
             readings=await self._get_readings(),
         )
 

--- a/custom_components/ppc_smgw/gateways/theben/theben.py
+++ b/custom_components/ppc_smgw/gateways/theben/theben.py
@@ -1,11 +1,11 @@
-import logging
 import asyncio
+import logging
 
 import httpx
 import urllib3
 
-from custom_components.ppc_smgw import Gateway
-from custom_components.ppc_smgw.gateways.reading import Information, FakeInformation
+from custom_components.ppc_smgw.gateways.gateway import Gateway
+from custom_components.ppc_smgw.gateways.reading import FakeInformation, Information
 from custom_components.ppc_smgw.gateways.theben.conexa.conexa import (
     ThebenConexaClient,
 )

--- a/custom_components/ppc_smgw/sensor.py
+++ b/custom_components/ppc_smgw/sensor.py
@@ -1,5 +1,5 @@
-import logging
 from datetime import datetime
+import logging
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant
@@ -20,7 +20,7 @@ PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/scripts/test_emh_local.py
+++ b/scripts/test_emh_local.py
@@ -17,13 +17,15 @@ Examples:
 """
 
 import asyncio
+from dataclasses import dataclass
+from datetime import datetime
 import importlib.util
 import logging
 import os
 import sys
 import types
-from dataclasses import dataclass
-from datetime import datetime
+
+import httpx
 
 # ---------------------------------------------------------------------------
 # Inline stubs for HA-dependent types used by emh_client.py
@@ -125,8 +127,6 @@ logger = logging.getLogger("emh_test")
 
 
 async def main(host: str, username: str, password: str, meter_id: str = "") -> None:
-    import httpx
-
     async with httpx.AsyncClient(verify=False) as client:
         emh = EMHCasaClient(
             base_url=host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,26 @@
 """Fixtures for PPC SMGW integration tests."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from homeassistant.const import (
+    CONF_DEBUG,
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
-    CONF_DEBUG,
 )
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.ppc_smgw.const import (
     CONF_METER_TYPE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from custom_components.ppc_smgw.gateways.emh import const as emh_const
-from custom_components.ppc_smgw.gateways.theben import const as theben_const
 from custom_components.ppc_smgw.gateways.ppc import const as ppc_const
+from custom_components.ppc_smgw.gateways.theben import const as theben_const
 from custom_components.ppc_smgw.gateways.vendors import Vendor
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,23 +2,24 @@
 
 from unittest.mock import patch
 
-import pytest
-from homeassistant.const import CONF_HOST
 from homeassistant.const import (
+    CONF_DEBUG,
+    CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
-    CONF_DEBUG,
+    CONF_USERNAME,
 )
-from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+import pytest
 
 from custom_components.ppc_smgw.config_flow import (
+    PPC_SMGLocalConfigFlow,
     PPCSMGWLocalOptionsFlowHandler,
 )
-from custom_components.ppc_smgw.config_flow import PPC_SMGLocalConfigFlow
 from custom_components.ppc_smgw.const import CONF_METER_TYPE
+from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
 from custom_components.ppc_smgw.gateways.vendors import Vendor
 from tests.conftest import create_mock_config_entry
 
@@ -106,8 +107,6 @@ class TestConfigFlow:
         self, hass: HomeAssistant, emh_config_data
     ):
         """Test that selecting a meter in the EMH meter-select step creates the entry."""
-        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
-
         flow = PPC_SMGLocalConfigFlow()
         flow.hass = hass
         flow.data = {**emh_config_data}
@@ -127,8 +126,6 @@ class TestConfigFlow:
         self, hass: HomeAssistant, emh_config_data
     ):
         """Test that the meter-select step shows a form when multiple meters are found."""
-        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
-
         flow = PPC_SMGLocalConfigFlow()
         flow.hass = hass
         flow.data = {**emh_config_data}
@@ -152,8 +149,6 @@ class TestConfigFlow:
         self, hass: HomeAssistant, emh_config_data
     ):
         """Test that discovery failure falls back to auto-detect and creates the entry."""
-        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
-
         flow = PPC_SMGLocalConfigFlow()
         flow.hass = hass
         flow.data = {**emh_config_data}
@@ -250,8 +245,6 @@ class TestConfigFlow:
         self, hass: HomeAssistant, emh_config_data
     ):
         """Test that selecting an already-configured meter shows an error."""
-        from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
-
         flow = PPC_SMGLocalConfigFlow()
         flow.hass = hass
         flow.data = {**emh_config_data}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,27 +3,26 @@
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-import pytz
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
-
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+import pytest
+import pytz
 
 from custom_components.ppc_smgw import async_setup_entry, async_unload_entry
 from custom_components.ppc_smgw.const import (
     CONF_METER_TYPE,
-    DEFAULT_SCAN_INTERVAL,
+    CONF_USE_LIBRARY,
     DOMAIN,
 )
 from custom_components.ppc_smgw.coordinator import (
-    SMGwDataUpdateCoordinator,
     Data,
+    SMGwDataUpdateCoordinator,
 )
 from custom_components.ppc_smgw.gateways.reading import Information, Reading
 from custom_components.ppc_smgw.gateways.vendors import Vendor
@@ -114,8 +113,6 @@ class TestInit:
         self, hass: HomeAssistant, ppc_config_data, mock_gateway
     ):
         """use_library from entry.data must be forwarded to PPC_SMGW."""
-        from custom_components.ppc_smgw.const import CONF_USE_LIBRARY
-
         config_data = {**ppc_config_data, CONF_USE_LIBRARY: True}
         entry = create_mock_config_entry(data=config_data)
 

--- a/tests/test_ppc_adapter.py
+++ b/tests/test_ppc_adapter.py
@@ -1,20 +1,19 @@
 """Tests for the PPC adapter's built-in vs library data paths."""
 
+from datetime import UTC, datetime
 import logging
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from obis_parser import OBIS
+from py_ppc_smgw.types import FirmwareVersion, Meter, Reading as LibReading
 import pytest
 
-from custom_components.ppc_smgw.gateways.ppc.ppc_smgw import PPC_SMGW
 from custom_components.ppc_smgw.gateways.ppc.const import (
     DEFAULT_MODEL,
     MANUFACTURER,
 )
+from custom_components.ppc_smgw.gateways.ppc.ppc_smgw import PPC_SMGW
 from custom_components.ppc_smgw.gateways.reading import Information, Reading
-
-from obis_parser import OBIS
-from py_ppc_smgw.types import FirmwareVersion, Meter, Reading as LibReading
 
 _ADAPTER = "custom_components.ppc_smgw.gateways.ppc.ppc_smgw"
 
@@ -59,7 +58,7 @@ class TestPPCAdapterDataPath:
             model="M",
             manufacturer="Mfr",
             firmware_version="1-2",
-            last_update=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            last_update=datetime(2024, 1, 1, tzinfo=UTC),
             readings={},
         )
         adapter.ppc_smgw_client.get_data = AsyncMock(return_value=canned)
@@ -161,7 +160,7 @@ class TestAsAware:
         assert PPC_SMGW._as_aware(None) is None
 
     def test_aware_datetime_is_returned_unchanged(self):
-        aware = datetime(2024, 12, 20, 16, 0, 1, tzinfo=timezone.utc)
+        aware = datetime(2024, 12, 20, 16, 0, 1, tzinfo=UTC)
         assert PPC_SMGW._as_aware(aware) is aware
 
     def test_naive_datetime_becomes_aware(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,27 +1,28 @@
 """Tests for the PPC SMGW sensor platform."""
 
-import pytest
 from dataclasses import replace
 from datetime import datetime
 from unittest.mock import MagicMock
+
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.core import HomeAssistant
+import pytest
+import pytz
 
+from custom_components.ppc_smgw.const import (
+    SENSOR_TYPES,
+    FirmwareVersionSensorDescription,
+    LastUpdatedSensorDescription,
+)
+from custom_components.ppc_smgw.coordinator import Data
+from custom_components.ppc_smgw.gateways.reading import Information, Reading
 from custom_components.ppc_smgw.sensor import (
     FirmwareSensor,
     LastUpdatedSensor,
     OBISSensor,
     async_setup_entry,
 )
-from custom_components.ppc_smgw.const import (
-    FirmwareVersionSensorDescription,
-    LastUpdatedSensorDescription,
-    SENSOR_TYPES,
-)
-from custom_components.ppc_smgw.gateways.reading import Information, Reading
-from custom_components.ppc_smgw.coordinator import Data
 from tests.conftest import create_mock_config_entry
-import pytz
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary by Sourcery

Enable Ruff linting and bring the integration’s source code, tests, and scripts into compliance with the project’s linting configuration.

Enhancements:
- Enable Ruff lint checks in the CI workflow and align the project codebase with the configured linting and formatting standards.

CI:
- Re-enable the Ruff linting step in the GitHub Actions workflow.

Tests:
- Update test code and fixtures to satisfy the enabled linting and formatting checks.

Chores:
- Expand Ruff configuration with project-wide, per-file, and import-sorting rules.