### PR TITLE
[PPC] Use py-ppc-smgw library per default

### DIFF
--- a/custom_components/ppc_smgw/__init__.py
+++ b/custom_components/ppc_smgw/__init__.py
@@ -23,13 +23,12 @@ from custom_components.ppc_smgw.gateways.vendors import Vendor
 
 from .const import (
     CONF_METER_TYPE,
-    CONF_USE_LIBRARY,
     DEFAULT_SCAN_INTERVAL,
-    DEFAULT_USE_LIBRARY,
     DOMAIN,
 )
 from .coordinator import ConfigEntry, Data, SMGwDataUpdateCoordinator
 from .gateways.emh.const import CONF_METER_ID as EMH_CONF_METER_ID
+from .gateways.ppc import const as ppc_const
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
@@ -70,7 +69,9 @@ async def async_setup_entry(
             _LOGGER.debug("Initializing PPC SMGW client")
             # entry.data is the single source of truth (options are merged into
             # data by the options flow), matching how CONF_DEBUG is read above.
-            use_library = entry.data.get(CONF_USE_LIBRARY, DEFAULT_USE_LIBRARY)
+            use_library = entry.data.get(
+                ppc_const.CONF_USE_LIBRARY, ppc_const.DEFAULT_USE_LIBRARY
+            )
             client = PPC_SMGW(
                 host=entry.data[CONF_HOST],
                 username=entry.data[CONF_USERNAME],
@@ -164,6 +165,20 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, minor_version=2, version=2
+        )
+
+    if config_entry.version == 2 and config_entry.minor_version < 3:
+        new_data = {**config_entry.data}
+        try:
+            vendor = Vendor(config_entry.data.get(CONF_METER_TYPE))
+        except (ValueError, TypeError):
+            vendor = Vendor.PPC
+
+        if vendor == Vendor.PPC:
+            new_data[ppc_const.CONF_USE_LIBRARY] = ppc_const.DEFAULT_USE_LIBRARY
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, minor_version=3, version=2
         )
 
     _LOGGER.debug(

--- a/custom_components/ppc_smgw/config_flow.py
+++ b/custom_components/ppc_smgw/config_flow.py
@@ -24,10 +24,8 @@ import voluptuous as vol
 
 from .const import (
     CONF_METER_TYPE,
-    CONF_USE_LIBRARY,
     DEFAULT_DEBUG,
     DEFAULT_SCAN_INTERVAL,
-    DEFAULT_USE_LIBRARY,
     DOMAIN,
     REPO_URL,
 )
@@ -56,7 +54,7 @@ def build_username_password_schema(
     optional_password: bool = False,
     default_meter_id: str | None = None,
     allow_use_library: bool = False,
-    default_use_library: bool = False,
+    default_use_library: bool = ppc_const.DEFAULT_USE_LIBRARY,
 ) -> vol.Schema:
     """Build a schema for username/password configuration.
 
@@ -97,7 +95,9 @@ def build_username_password_schema(
         schema[vol.Optional(CONF_DEBUG, default=default_debug)] = bool
 
     if allow_use_library:
-        schema[vol.Optional(CONF_USE_LIBRARY, default=default_use_library)] = bool
+        schema[
+            vol.Optional(ppc_const.CONF_USE_LIBRARY, default=default_use_library)
+        ] = bool
 
     if default_meter_id is not None:
         schema[vol.Optional(emh_const.CONF_METER_ID, default=default_meter_id)] = str
@@ -148,7 +148,7 @@ def _host_username_combination_exists(
 
 class PPC_SMGLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 2
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
@@ -419,14 +419,16 @@ class PPCSMGWLocalOptionsFlowHandler(config_entries.OptionsFlow):
         # Determine if this is a PPC device (only vendor with debug option)
         is_ppc = vendor == Vendor.PPC
         current_debug = DEFAULT_DEBUG
-        current_use_library = DEFAULT_USE_LIBRARY
+        current_use_library = ppc_const.DEFAULT_USE_LIBRARY
         if is_ppc:
             current_debug = self.options.get(
                 CONF_DEBUG, self.data.get(CONF_DEBUG, DEFAULT_DEBUG)
             )
             current_use_library = self.options.get(
-                CONF_USE_LIBRARY,
-                self.data.get(CONF_USE_LIBRARY, DEFAULT_USE_LIBRARY),
+                ppc_const.CONF_USE_LIBRARY,
+                self.data.get(
+                    ppc_const.CONF_USE_LIBRARY, ppc_const.DEFAULT_USE_LIBRARY
+                ),
             )
 
         # For EMH, include the meter_id field

--- a/custom_components/ppc_smgw/const.py
+++ b/custom_components/ppc_smgw/const.py
@@ -17,12 +17,6 @@ REPO_URL = "https://github.com/jannickfahlbusch/ha-ppc-smgw"
 
 CONF_METER_TYPE = "meter_type"
 
-# Opt-in toggle (PPC options flow only) to route data fetching through the
-# standalone py-ppc-smgw library instead of the built-in client. Default keeps
-# the built-in client so existing installations are unaffected.
-CONF_USE_LIBRARY = "use_library"
-DEFAULT_USE_LIBRARY = False
-
 SENSOR_TYPES = [
     SensorEntityDescription(
         key="1-0:1.8.0",

--- a/custom_components/ppc_smgw/gateways/ppc/const.py
+++ b/custom_components/ppc_smgw/gateways/ppc/const.py
@@ -2,3 +2,6 @@ DEFAULT_MODEL = "LTE Smart Meter Gateway"
 DEFAULT_NAME = "PPC SMGW"
 DEFAULT_URL = "https://192.168.1.200/cgi-bin/hanservice.cgi"
 MANUFACTURER = "Power Plus Communications AG"
+
+CONF_USE_LIBRARY = "use_library"
+DEFAULT_USE_LIBRARY = True

--- a/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
@@ -63,8 +63,10 @@ class PPC_SMGW(Gateway):
             await asyncio.sleep(15)
             self.data = FakeInformation
         elif self.use_library:
+            self.logger.debug("Using py-ppc-smgw library for data fetching")
             self.data = await self._get_data_via_library()
         else:
+            self.logger.debug("Using legacy in-tree PPC client")
             self.data = await self.ppc_smgw_client.get_data()
 
         return self.data

--- a/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
+++ b/custom_components/ppc_smgw/gateways/ppc/ppc_smgw.py
@@ -13,6 +13,7 @@ from custom_components.ppc_smgw.gateways.gateway import Gateway
 from custom_components.ppc_smgw.gateways.ppc.const import (
     DEFAULT_MODEL,
     DEFAULT_NAME,
+    DEFAULT_USE_LIBRARY,
     MANUFACTURER,
 )
 from custom_components.ppc_smgw.gateways.ppc.ppcsmgw.ppc_smgw import PPCSmgw
@@ -35,12 +36,12 @@ class PPC_SMGW(Gateway):
         websession: httpx.AsyncClient,
         logger: logging.Logger,
         debug: bool = False,
-        use_library: bool = False,
+        use_library: bool = DEFAULT_USE_LIBRARY,
     ) -> None:
         super().__init__(host, username, password, websession, logger, debug)
 
-        # Opt-in flag: route through the py-ppc-smgw library instead of the
-        # built-in client. Default keeps the built-in client (below) unchanged.
+        # Feature toggle flag: route through the py-ppc-smgw library instead of the
+        # built-in client. Default uses the py-ppc-smgw library.
         self.use_library = use_library
 
         self.ppc_smgw_client = PPCSmgw(

--- a/custom_components/ppc_smgw/strings.json
+++ b/custom_components/ppc_smgw/strings.json
@@ -31,12 +31,12 @@
           "password": "[%key:common::config_flow::data::password%]",
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "debug": "Development mode - DO NOT USE (Uses fake data)",
-          "use_library": "Use py-ppc-smgw client library (experimental)",
+          "use_library": "Use py-ppc-smgw client library",
           "meter_id": "Meter ID (EMH only — leave blank for auto-detect)"
         },
         "data_description": {
           "password": "Leave blank to keep the current password",
-          "use_library": "Leave off to keep the built-in client (default)."
+          "use_library": "Leave enabled to use the py-ppc-smgw library (default). Disable to fall back to the legacy built-in client if you observe issues."
         }
       }
     }

--- a/custom_components/ppc_smgw/translations/en.json
+++ b/custom_components/ppc_smgw/translations/en.json
@@ -40,12 +40,12 @@
             "password": "Password",
             "scan_interval": "Polling Interval in minutes",
             "debug": "Development mode - DO NOT USE (Uses fake data)",
-            "use_library": "Use py-ppc-smgw client library (experimental)",
+            "use_library": "Use py-ppc-smgw client library",
             "meter_id": "Meter ID (EMH only — leave blank for auto-detect)"
           },
           "data_description": {
             "password": "Leave blank to keep the current password",
-            "use_library": "Leave off to keep the built-in client (default)."
+            "use_library": "Leave enabled to use the py-ppc-smgw library (default). Disable to fall back to the legacy built-in client if you observe issues."
           }
         }
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,13 @@ def create_mock_config_entry(
     data: dict,
     entry_id: str = "test_entry_id",
     options: dict | None = None,
+    version: int = 2,
+    minor_version: int = 3,
 ) -> MockConfigEntry:
     """Factory function to create ConfigEntry objects for testing."""
     return MockConfigEntry(
-        version=2,
-        minor_version=2,
+        version=version,
+        minor_version=minor_version,
         domain=DOMAIN,
         title=data.get(CONF_NAME, "Test Entry"),
         data=data,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,7 @@ from custom_components.ppc_smgw.config_flow import (
 )
 from custom_components.ppc_smgw.const import CONF_METER_TYPE
 from custom_components.ppc_smgw.gateways.emh.const import CONF_METER_ID
+from custom_components.ppc_smgw.gateways.ppc import const as ppc_const
 from custom_components.ppc_smgw.gateways.vendors import Vendor
 from tests.conftest import create_mock_config_entry
 
@@ -375,16 +376,20 @@ class TestOptionsFlow:
             user_input={
                 k: ppc_config_data[k] for k in ["name", "host", "username", "password"]
             }
-            | {"scan_interval": 5, "debug": False, "use_library": True}
+            | {
+                CONF_SCAN_INTERVAL: 5,
+                CONF_DEBUG: False,
+                ppc_const.CONF_USE_LIBRARY: True,
+            }
         )
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert entry.data["use_library"] is True
+        assert entry.data[ppc_const.CONF_USE_LIBRARY] is True
 
-    async def test_options_flow_use_library_defaults_false_when_absent(
+    async def test_options_flow_disables_use_library_when_opted_out(
         self, hass: HomeAssistant, ppc_config_data
     ):
-        """Omitting use_library leaves the built-in client (default) active."""
+        """Opting out of use_library (False) persists it to entry.data."""
         entry = create_mock_config_entry(data=ppc_config_data)
         hass.config_entries._entries[entry.entry_id] = entry
         options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
@@ -394,11 +399,32 @@ class TestOptionsFlow:
             user_input={
                 k: ppc_config_data[k] for k in ["name", "host", "username", "password"]
             }
-            | {"scan_interval": 5, "debug": False}
+            | {
+                CONF_SCAN_INTERVAL: 5,
+                CONF_DEBUG: False,
+                ppc_const.CONF_USE_LIBRARY: False,
+            }
         )
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert entry.data.get("use_library", False) is False
+        assert entry.data[ppc_const.CONF_USE_LIBRARY] is False
+
+    async def test_options_schema_defaults_use_library_to_true(
+        self, hass: HomeAssistant, ppc_config_data
+    ):
+        """use_library must default to True in the options schema for PPC."""
+        entry = create_mock_config_entry(data=ppc_config_data)
+        hass.config_entries._entries[entry.entry_id] = entry
+        options_flow = PPCSMGWLocalOptionsFlowHandler(entry)
+        options_flow.hass = hass
+
+        schema = options_flow._build_options_schema()
+        use_library_marker = next(
+            k
+            for k in schema.schema
+            if getattr(k, "schema", k) == ppc_const.CONF_USE_LIBRARY
+        )
+        assert use_library_marker.default() is True
 
     async def test_options_schema_shows_ppc_toggles_for_string_meter_type(
         self, hass: HomeAssistant, ppc_config_data
@@ -418,8 +444,8 @@ class TestOptionsFlow:
         schema = options_flow._build_options_schema()
         keys = {getattr(k, "schema", k) for k in schema.schema}
 
-        assert "use_library" in keys
-        assert "debug" in keys
+        assert ppc_const.CONF_USE_LIBRARY in keys
+        assert CONF_DEBUG in keys
 
     async def test_options_schema_falls_back_to_ppc_for_unknown_meter_type(
         self, hass: HomeAssistant, ppc_config_data
@@ -439,5 +465,5 @@ class TestOptionsFlow:
         schema = options_flow._build_options_schema()
         keys = {getattr(k, "schema", k) for k in schema.schema}
 
-        assert "use_library" in keys
-        assert "debug" in keys
+        assert ppc_const.CONF_USE_LIBRARY in keys
+        assert CONF_DEBUG in keys

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,16 +14,20 @@ from homeassistant.exceptions import ConfigEntryNotReady
 import pytest
 import pytz
 
-from custom_components.ppc_smgw import async_setup_entry, async_unload_entry
+from custom_components.ppc_smgw import (
+    async_migrate_entry,
+    async_setup_entry,
+    async_unload_entry,
+)
 from custom_components.ppc_smgw.const import (
     CONF_METER_TYPE,
-    CONF_USE_LIBRARY,
     DOMAIN,
 )
 from custom_components.ppc_smgw.coordinator import (
     Data,
     SMGwDataUpdateCoordinator,
 )
+from custom_components.ppc_smgw.gateways.ppc import const as ppc_const
 from custom_components.ppc_smgw.gateways.reading import Information, Reading
 from custom_components.ppc_smgw.gateways.vendors import Vendor
 from tests.conftest import create_mock_config_entry
@@ -113,7 +117,7 @@ class TestInit:
         self, hass: HomeAssistant, ppc_config_data, mock_gateway
     ):
         """use_library from entry.data must be forwarded to PPC_SMGW."""
-        config_data = {**ppc_config_data, CONF_USE_LIBRARY: True}
+        config_data = {**ppc_config_data, ppc_const.CONF_USE_LIBRARY: True}
         entry = create_mock_config_entry(data=config_data)
 
         mock_integration = MagicMock()
@@ -137,12 +141,12 @@ class TestInit:
         ):
             await async_setup_entry(hass, entry)
 
-        assert ppc_cls.call_args.kwargs["use_library"] is True
+        assert ppc_cls.call_args.kwargs[ppc_const.CONF_USE_LIBRARY] is True
 
-    async def test_setup_entry_defaults_use_library_false(
+    async def test_setup_entry_defaults_use_library_true(
         self, hass: HomeAssistant, ppc_config_data, mock_gateway
     ):
-        """Without the key in entry.data, PPC_SMGW must get use_library=False."""
+        """Without the key in entry.data, PPC_SMGW must get use_library=True."""
         entry = create_mock_config_entry(data=ppc_config_data)
 
         mock_integration = MagicMock()
@@ -166,7 +170,37 @@ class TestInit:
         ):
             await async_setup_entry(hass, entry)
 
-        assert ppc_cls.call_args.kwargs["use_library"] is False
+        assert ppc_cls.call_args.kwargs[ppc_const.CONF_USE_LIBRARY] is True
+
+    async def test_setup_entry_passes_use_library_false_when_opted_out(
+        self, hass: HomeAssistant, ppc_config_data, mock_gateway
+    ):
+        """When use_library is explicitly False in entry.data, PPC_SMGW must get use_library=False."""
+        config_data = {**ppc_config_data, ppc_const.CONF_USE_LIBRARY: False}
+        entry = create_mock_config_entry(data=config_data)
+
+        mock_integration = MagicMock()
+        mock_integration.domain = DOMAIN
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        ppc_cls = MagicMock(return_value=mock_gateway)
+
+        with (
+            patch("custom_components.ppc_smgw.PPC_SMGW", ppc_cls),
+            patch("custom_components.ppc_smgw.create_async_httpx_client"),
+            patch(
+                "custom_components.ppc_smgw.async_get_loaded_integration",
+                return_value=mock_integration,
+            ),
+            patch.object(hass.config_entries, "async_forward_entry_setups"),
+            patch(
+                "custom_components.ppc_smgw.SMGwDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        assert ppc_cls.call_args.kwargs[ppc_const.CONF_USE_LIBRARY] is False
 
     async def test_setup_entry_uses_configured_scan_interval(
         self, hass: HomeAssistant, mock_gateway
@@ -362,3 +396,59 @@ class TestCoordinator:
         # Test: coordinator returns None without raising
         result = await coordinator._async_update_data()
         assert result is None
+
+
+@pytest.mark.asyncio
+class TestMigration:
+    """Test config entry version migrations."""
+
+    async def test_migrate_v1_to_v2_3(self, hass: HomeAssistant):
+        """v1 entry migrates to v2.3 with Vendor.PPC and use_library=True."""
+        old_data = {
+            "name": "PPC SMGW",
+            "host": "https://192.168.1.200/cgi-bin/hanservice.cgi",
+            "username": "testuser",
+            "password": "testpass",
+            "scan_interval": 5,
+        }
+        entry = create_mock_config_entry(data=old_data, version=1, minor_version=1)
+        hass.config_entries._entries[entry.entry_id] = entry
+
+        result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        assert entry.version == 2
+        assert entry.minor_version == 3
+        assert entry.data[CONF_METER_TYPE] == Vendor.PPC
+        assert entry.data[ppc_const.CONF_USE_LIBRARY] is True
+
+    async def test_migrate_v2_2_ppc_to_v2_3(self, hass: HomeAssistant, ppc_config_data):
+        """v2.2 PPC entry migrates to v2.3 with use_library=True."""
+        # Entry might have had use_library=False from older opt-in default
+        data = {**ppc_config_data, ppc_const.CONF_USE_LIBRARY: False}
+        entry = create_mock_config_entry(data=data, version=2, minor_version=2)
+        hass.config_entries._entries[entry.entry_id] = entry
+
+        result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        assert entry.version == 2
+        assert entry.minor_version == 3
+        assert entry.data[CONF_METER_TYPE] == Vendor.PPC
+        assert entry.data[ppc_const.CONF_USE_LIBRARY] is True
+
+    async def test_migrate_v2_2_non_ppc_to_v2_3(
+        self, hass: HomeAssistant, theben_config_data
+    ):
+        """v2.2 Theben entry migrates to v2.3 without setting PPC-specific use_library."""
+        entry = create_mock_config_entry(
+            data=theben_config_data, version=2, minor_version=2
+        )
+        hass.config_entries._entries[entry.entry_id] = entry
+
+        result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        assert entry.version == 2
+        assert entry.minor_version == 3
+        assert ppc_const.CONF_USE_LIBRARY not in entry.data

--- a/tests/test_ppc_adapter.py
+++ b/tests/test_ppc_adapter.py
@@ -194,3 +194,15 @@ class TestPPCAdapterReboot:
 
         factory.client.reboot.assert_awaited_once()
         adapter.ppc_smgw_client.reboot.assert_not_awaited()
+
+
+def test_ppc_smgw_defaults_use_library_to_true():
+    """PPC_SMGW constructor defaults use_library to True when omitted."""
+    adapter = PPC_SMGW(
+        host="https://192.168.1.200/cgi-bin/hanservice.cgi",
+        username="testuser",
+        password="testpass",
+        websession=MagicMock(),
+        logger=logging.getLogger("test.ppc_adapter"),
+    )
+    assert adapter.use_library is True


### PR DESCRIPTION
## Summary by Sourcery

Make the py-ppc-smgw library the default PPC client and migrate existing entries to the updated configuration behavior.

New Features:
- Use the py-ppc-smgw library by default for PPC data fetching, while retaining an explicit opt-out to the legacy client.

Enhancements:
- Move the PPC library toggle and default into PPC-specific constants and consistently apply the default across setup, configuration flows, and the adapter.
- Migrate existing configuration entries to the new PPC library-default behavior.

Tests:
- Add coverage for the new default, explicit opt-out, configuration flow behavior, adapter defaults, and configuration migrations.