### PR TITLE
Move LastUpdatedSensor into Diagnostics section

### DIFF
--- a/custom_components/ppc_smgw/const.py
+++ b/custom_components/ppc_smgw/const.py
@@ -45,6 +45,7 @@ LastUpdatedSensorDescription = SensorEntityDescription(
     icon="mdi:clock-time-eight",
     native_unit_of_measurement=None,
     device_class=SensorDeviceClass.TIMESTAMP,
+    entity_category=EntityCategory.DIAGNOSTIC,
 )
 
 FirmwareVersionSensorDescription = SensorEntityDescription(


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Classify the LastUpdatedSensor as a diagnostic entity so it appears in Home Assistant’s Diagnostics section.